### PR TITLE
Fixed issue Where .fbx files Were Being imported Improperly

### DIFF
--- a/Prowl.Editor/EditorWindows/HierarchyWindow.cs
+++ b/Prowl.Editor/EditorWindows/HierarchyWindow.cs
@@ -100,8 +100,19 @@ public class HierarchyWindow : EditorWindow {
                 if (DragnDrop.ReceiveAsset<GameObject>(out var original))
                 {
                     GameObject clone = (GameObject)EngineObject.Instantiate(original.Res!, true);
+                    clone.Scale = original.Res!.Scale;
                     clone.Position = original.Res!.Position;
                     clone.Orientation = original.Res!.Orientation;
+                    clone.Rotation = original.Res!.Rotation;
+
+                    foreach (var child in clone.Children)
+                    {
+                        child.Scale = original.Res!.Scale;
+                        child.Orientation = original.Res!.Orientation;
+                        child.Position = original.Res!.Position;
+                        child.Rotation = original.Res!.Rotation;
+                    }
+
                     clone.SetParent(null);
                     clone.Recalculate();
                     Selection.Select(clone);
@@ -211,9 +222,20 @@ public class HierarchyWindow : EditorWindow {
         if (DragnDrop.ReceiveAsset<GameObject>(out var original))
         {
             GameObject clone = (GameObject)EngineObject.Instantiate(original.Res!, true);
-            clone.Position = original.Res!.Position;
-            clone.Orientation = original.Res!.Orientation;
-            clone.SetParent(entity);
+			clone.Scale = original.Res!.Scale;
+			clone.Position = original.Res!.Position;
+			clone.Orientation = original.Res!.Orientation;
+			clone.Rotation = original.Res!.Rotation;
+
+			foreach (var child in clone.Children)
+			{
+				child.Scale = original.Res!.Scale;
+				child.Orientation = original.Res!.Orientation;
+				child.Position = original.Res!.Position;
+				child.Rotation = original.Res!.Rotation;
+			}
+
+			clone.SetParent(entity);
             clone.Recalculate();
             Selection.Select(clone);
         }


### PR DESCRIPTION
This fix is for issue #26. It turns out the issue is caused by Json deserialization of the object. I wasn't able to pinpoint exactly where at in the deseiralization the scale was becoming changed but the lines of code I implemented should fix the issue. Oddly enough, the 2nd tier child in the hierarchy was where the issue was manifesting from.

In addition to the scale issue, the rotation of the object was off as well. Implemented a fix for that as well

![2023-11-27 22_13_28-Prowl](https://github.com/michaelsakharov/Prowl/assets/55113224/288970da-6e14-4aaf-b788-661418121e54)

With these changes, it might be better to change up the `EngineObject.Instantiate()` to return a GameObject instead of an engineObject to reduce the amount of casting in the other methods. I noticed the `Instantiate()` method is only being called in the hierarchy so it wouldn't be too hard to implement. Let me know if that's something you want me to implement or if there's anything I'm missing.