### PR TITLE
simple config dir check

### DIFF
--- a/Prowl.Editor/EditorApplication.cs
+++ b/Prowl.Editor/EditorApplication.cs
@@ -49,6 +49,10 @@ public unsafe class EditorApplication : Application {
     {
         string filePath = Path.Combine(Project.Projects_Directory, "EditorConfig.setting");
         string json = JsonSerializer.Serialize(EditorConfig);
+
+        if(!Directory.Exists(Project.Projects_Directory)) 
+            Directory.CreateDirectory(Project.Projects_Directory);
+
         File.WriteAllText(filePath, json);
     }
 


### PR DESCRIPTION
Looks bad but, It seems that the script can't find `Project.Projects_Directory` on first build and halts at `File.WriteAllText`. However If you'd manually create the dir, build again, then AGAIN also delete the dir, the saving will work fine forever, so its weird. 

summary:
`File.WriteAllText` can create both the file and directory just not when building first time, for some reason.