### PR TITLE
Switch Bindings

### DIFF
--- a/Prowl.Editor/Assets/Importers/MaterialImporter.cs
+++ b/Prowl.Editor/Assets/Importers/MaterialImporter.cs
@@ -1,4 +1,4 @@
-﻿using HexaEngine.ImGuiNET;
+﻿using Hexa.NET.ImGui;
 using Prowl.Editor.PropertyDrawers;
 using Prowl.Runtime;
 using Prowl.Runtime.Assets;

--- a/Prowl.Editor/Assets/Importers/ModelImporter.cs
+++ b/Prowl.Editor/Assets/Importers/ModelImporter.cs
@@ -1,5 +1,5 @@
 ﻿using Assimp;
-using HexaEngine.ImGuiNET;
+using Hexa.NET.ImGui;
 using Prowl.Runtime;
 using Prowl.Runtime.Assets;
 using Prowl.Runtime.Utils;

--- a/Prowl.Editor/Assets/Importers/TextureImporter.cs
+++ b/Prowl.Editor/Assets/Importers/TextureImporter.cs
@@ -1,6 +1,6 @@
 ﻿using Prowl.Runtime;
 using Prowl.Runtime.Utils;
-using HexaEngine.ImGuiNET;
+using Hexa.NET.ImGui;
 using Prowl.Runtime.Assets;
 using Silk.NET.OpenGL;
 

--- a/Prowl.Editor/Drawers/NodeSystem/NodeSystemDrawer.cs
+++ b/Prowl.Editor/Drawers/NodeSystem/NodeSystemDrawer.cs
@@ -1,5 +1,5 @@
-﻿using HexaEngine.ImGuiNET;
-using HexaEngine.ImNodesNET;
+﻿using Hexa.NET.ImGui;
+using Hexa.NET.ImNodes;
 using Prowl.Editor.PropertyDrawers;
 using Prowl.Runtime;
 using Prowl.Runtime.NodeSystem;

--- a/Prowl.Editor/Drawers/PropertyDrawer.cs
+++ b/Prowl.Editor/Drawers/PropertyDrawer.cs
@@ -1,4 +1,4 @@
-using HexaEngine.ImGuiNET;
+using Hexa.NET.ImGui;
 using Prowl.Runtime;
 using System.Reflection;
 using System.Text;

--- a/Prowl.Editor/Drawers/PropertyDrawerAsset.cs
+++ b/Prowl.Editor/Drawers/PropertyDrawerAsset.cs
@@ -1,4 +1,4 @@
-﻿using HexaEngine.ImGuiNET;
+﻿using Hexa.NET.ImGui;
 using Prowl.Icons;
 using Prowl.Runtime;
 using Prowl.Runtime.Assets;

--- a/Prowl.Editor/Drawers/PropertyDrawerBool.cs
+++ b/Prowl.Editor/Drawers/PropertyDrawerBool.cs
@@ -1,4 +1,4 @@
-using HexaEngine.ImGuiNET;
+using Hexa.NET.ImGui;
 
 namespace Prowl.Editor.PropertyDrawers;
 

--- a/Prowl.Editor/Drawers/PropertyDrawerColor.cs
+++ b/Prowl.Editor/Drawers/PropertyDrawerColor.cs
@@ -1,5 +1,5 @@
 using Prowl.Runtime;
-using HexaEngine.ImGuiNET;
+using Hexa.NET.ImGui;
 using System.Threading.Channels;
 
 namespace Prowl.Editor.PropertyDrawers;

--- a/Prowl.Editor/Drawers/PropertyDrawerFloat.cs
+++ b/Prowl.Editor/Drawers/PropertyDrawerFloat.cs
@@ -1,4 +1,4 @@
-using HexaEngine.ImGuiNET;
+using Hexa.NET.ImGui;
 using Prowl.Runtime;
 
 namespace Prowl.Editor.PropertyDrawers; 

--- a/Prowl.Editor/Drawers/PropertyDrawerQuaternion.cs
+++ b/Prowl.Editor/Drawers/PropertyDrawerQuaternion.cs
@@ -1,4 +1,4 @@
-using HexaEngine.ImGuiNET;
+using Hexa.NET.ImGui;
 using Prowl.Runtime;
 
 namespace Prowl.Editor.PropertyDrawers;

--- a/Prowl.Editor/Drawers/PropertyDrawerString.cs
+++ b/Prowl.Editor/Drawers/PropertyDrawerString.cs
@@ -1,4 +1,4 @@
-using HexaEngine.ImGuiNET;
+using Hexa.NET.ImGui;
 
 namespace Prowl.Editor.PropertyDrawers;
 

--- a/Prowl.Editor/Drawers/PropertyDrawerVector2.cs
+++ b/Prowl.Editor/Drawers/PropertyDrawerVector2.cs
@@ -1,4 +1,4 @@
-using HexaEngine.ImGuiNET;
+using Hexa.NET.ImGui;
 using Prowl.Runtime;
 
 namespace Prowl.Editor.PropertyDrawers;

--- a/Prowl.Editor/Drawers/PropertyDrawerVector3.cs
+++ b/Prowl.Editor/Drawers/PropertyDrawerVector3.cs
@@ -1,4 +1,4 @@
-using HexaEngine.ImGuiNET;
+using Hexa.NET.ImGui;
 using Prowl.Runtime;
 
 namespace Prowl.Editor.PropertyDrawers;

--- a/Prowl.Editor/EditorApplication.cs
+++ b/Prowl.Editor/EditorApplication.cs
@@ -1,4 +1,4 @@
-using HexaEngine.ImGuiNET;
+using Hexa.NET.ImGui;
 using Prowl.Editor.Assets;
 using Prowl.Editor.Drawers.NodeSystem;
 using Prowl.Editor.EditorWindows;

--- a/Prowl.Editor/EditorGui.cs
+++ b/Prowl.Editor/EditorGui.cs
@@ -1,4 +1,4 @@
-using HexaEngine.ImGuiNET;
+using Hexa.NET.ImGui;
 using Prowl.Editor.EditorWindows;
 using Prowl.Runtime;
 using System.Reflection;

--- a/Prowl.Editor/EditorMainMenubar.cs
+++ b/Prowl.Editor/EditorMainMenubar.cs
@@ -1,13 +1,13 @@
 using Prowl.Runtime;
 using Prowl.Icons;
-using HexaEngine.ImGuiNET;
+using Hexa.NET.ImGui;
 using System.Numerics;
 using System.Runtime.InteropServices;
 
 namespace Prowl.Editor.EditorWindows;
 
 public class EditorMainMenubar {
-    
+
     private struct Position {
         public int X;
         public int Y;
@@ -21,11 +21,11 @@ public class EditorMainMenubar {
     private Position _mousePosRef;
 
     private bool _dragging;
-    
+
     public EditorMainMenubar() {
         EditorApplication.OnDrawEditor += Draw;
     }
-    
+
     private void Draw() {
         ImGui.PushStyleVar(ImGuiStyleVar.FramePadding, new System.Numerics.Vector2(4, 4));
         if(ImGui.BeginMainMenuBar()) {
@@ -40,24 +40,24 @@ public class EditorMainMenubar {
             GUIHelper.Tooltip("Recompile Project Scripts.");
 
 
-            ImGui.EndMainMenuBar();   
+            ImGui.EndMainMenuBar();
         }
         // pop main menu bar size
         ImGui.PopStyleVar();
     }
 
     private static void DrawPlayControls() {
-        
+
         void AlignForWidth(float width, float alignment = 0.5f) {
             float avail = ImGui.GetContentRegionAvail().X;
             float off = (avail - width) * alignment;
             if(off > 0.0f)
                 ImGui.SetCursorPosX(off);
         }
-        
+
         ImGuiStylePtr style = ImGui.GetStyle();
         float width = 0.0f;
-        
+
         switch(PlayMode.Current) {
             case PlayMode.Mode.Editing:
                 width += ImGui.CalcTextSize(" " + FontAwesome6.Play).X;
@@ -71,7 +71,7 @@ public class EditorMainMenubar {
                 width += style.ItemSpacing.X;
                 width += ImGui.CalcTextSize(" " + FontAwesome6.Stop).X;
                 AlignForWidth(width);
-                
+
                 if(ImGui.Button(" " + FontAwesome6.Pause))
                     PlayMode.Pause();
                 if(ImGui.Button(" " + FontAwesome6.Stop))
@@ -82,7 +82,7 @@ public class EditorMainMenubar {
                 width += style.ItemSpacing.X;
                 width += ImGui.CalcTextSize(" " + FontAwesome6.Stop).X;
                 AlignForWidth(width);
-                
+
                 if(ImGui.Button(" " + FontAwesome6.Play))
                     PlayMode.Resume();
                 if(ImGui.Button(" " + FontAwesome6.Stop))
@@ -92,7 +92,7 @@ public class EditorMainMenubar {
                 throw new ArgumentOutOfRangeException();
         }
     }
-    
+
     private static void DrawMenuItems()
     {
         ImGui.SetCursorPosX(2);
@@ -127,11 +127,11 @@ public class EditorMainMenubar {
             if(ImGui.MenuItem("Utilities")) { new UtilitiesWindow(); }
             ImGui.EndMenu();
         }
-        
+
         if(ImGui.BeginMenu("Help")) {
             if(ImGui.MenuItem("Tip: Just get good.")) { }
             ImGui.EndMenu();
         }
     }
-    
+
 }

--- a/Prowl.Editor/EditorWindows/AssetBrowserWindow.cs
+++ b/Prowl.Editor/EditorWindows/AssetBrowserWindow.cs
@@ -1,4 +1,4 @@
-using HexaEngine.ImGuiNET;
+using Hexa.NET.ImGui;
 using Prowl.Editor.Assets;
 using Prowl.Editor.ImGUI.Widgets;
 using Prowl.Icons;

--- a/Prowl.Editor/EditorWindows/AssetsWindow.cs
+++ b/Prowl.Editor/EditorWindows/AssetsWindow.cs
@@ -1,4 +1,4 @@
-using HexaEngine.ImGuiNET;
+using Hexa.NET.ImGui;
 using Prowl.Editor.Assets;
 using Prowl.Editor.ImGUI.Widgets;
 using Prowl.Icons;

--- a/Prowl.Editor/EditorWindows/ConsoleWindow.cs
+++ b/Prowl.Editor/EditorWindows/ConsoleWindow.cs
@@ -1,5 +1,5 @@
 using Prowl.Runtime;
-using HexaEngine.ImGuiNET;
+using Hexa.NET.ImGui;
 using System.Numerics;
 using Prowl.Icons;
 

--- a/Prowl.Editor/EditorWindows/CustomEditors/GameObjectEditor.cs
+++ b/Prowl.Editor/EditorWindows/CustomEditors/GameObjectEditor.cs
@@ -1,5 +1,5 @@
 ﻿using Assimp;
-using HexaEngine.ImGuiNET;
+using Hexa.NET.ImGui;
 using Prowl.Editor.Assets;
 using Prowl.Editor.PropertyDrawers;
 using Prowl.Runtime;

--- a/Prowl.Editor/EditorWindows/CustomEditors/ScriptableObjectEditor.cs
+++ b/Prowl.Editor/EditorWindows/CustomEditors/ScriptableObjectEditor.cs
@@ -1,4 +1,4 @@
-﻿using HexaEngine.ImGuiNET;
+﻿using Hexa.NET.ImGui;
 using Prowl.Editor.Assets;
 using Prowl.Editor.PropertyDrawers;
 using Prowl.Runtime;

--- a/Prowl.Editor/EditorWindows/EditorWindow.cs
+++ b/Prowl.Editor/EditorWindows/EditorWindow.cs
@@ -1,4 +1,4 @@
-using HexaEngine.ImGuiNET;
+using Hexa.NET.ImGui;
 using System.Numerics;
 
 namespace Prowl.Editor.EditorWindows;

--- a/Prowl.Editor/EditorWindows/GameWindow.cs
+++ b/Prowl.Editor/EditorWindows/GameWindow.cs
@@ -1,4 +1,4 @@
-﻿using HexaEngine.ImGuiNET;
+﻿using Hexa.NET.ImGui;
 using Prowl.Icons;
 using Prowl.Runtime;
 using System.Numerics;

--- a/Prowl.Editor/EditorWindows/HierarchyWindow.cs
+++ b/Prowl.Editor/EditorWindows/HierarchyWindow.cs
@@ -1,4 +1,4 @@
-using HexaEngine.ImGuiNET;
+using Hexa.NET.ImGui;
 using Prowl.Icons;
 using Prowl.Runtime;
 using Prowl.Editor.ImGUI.Widgets;

--- a/Prowl.Editor/EditorWindows/InspectorWindow.cs
+++ b/Prowl.Editor/EditorWindows/InspectorWindow.cs
@@ -1,4 +1,4 @@
-using HexaEngine.ImGuiNET;
+using Hexa.NET.ImGui;
 using Prowl.Editor.Assets;
 using Prowl.Icons;
 using Prowl.Runtime;

--- a/Prowl.Editor/EditorWindows/ProjectSettingsWindow.cs
+++ b/Prowl.Editor/EditorWindows/ProjectSettingsWindow.cs
@@ -1,6 +1,6 @@
 using Prowl.Runtime;
 using Prowl.Editor.PropertyDrawers;
-using HexaEngine.ImGuiNET;
+using Hexa.NET.ImGui;
 using System.Numerics;
 using System.Reflection;
 using Prowl.Icons;

--- a/Prowl.Editor/EditorWindows/ProjectsWindow.cs
+++ b/Prowl.Editor/EditorWindows/ProjectsWindow.cs
@@ -1,4 +1,4 @@
-﻿using HexaEngine.ImGuiNET;
+﻿using Hexa.NET.ImGui;
 using Prowl.Icons;
 using Prowl.Runtime;
 

--- a/Prowl.Editor/EditorWindows/RenderPipelineWindow.cs
+++ b/Prowl.Editor/EditorWindows/RenderPipelineWindow.cs
@@ -1,4 +1,4 @@
-﻿using HexaEngine.ImGuiNET;
+﻿using Hexa.NET.ImGui;
 using Prowl.Editor.Drawers.NodeSystem;
 using Prowl.Icons;
 using Prowl.Runtime;

--- a/Prowl.Editor/EditorWindows/UtilitiesWindow.cs
+++ b/Prowl.Editor/EditorWindows/UtilitiesWindow.cs
@@ -1,4 +1,4 @@
-﻿using HexaEngine.ImGuiNET;
+﻿using Hexa.NET.ImGui;
 using Prowl.Icons;
 using Prowl.Runtime;
 

--- a/Prowl.Editor/EditorWindows/ViewportWindow.cs
+++ b/Prowl.Editor/EditorWindows/ViewportWindow.cs
@@ -1,5 +1,5 @@
-using HexaEngine.ImGuiNET;
-using HexaEngine.ImGuizmoNET;
+using Hexa.NET.ImGui;
+using Hexa.NET.ImGuizmo;
 using Jitter2.LinearMath;
 using Prowl.Editor.ImGUI.Widgets;
 using Prowl.Icons;
@@ -354,7 +354,7 @@ public class ViewportWindow : EditorWindow
             rot.y += mouseDelta.X * (Time.deltaTimeF * 5f * Settings.LookSensitivity);
             rot.x += mouseDelta.Y * (Time.deltaTimeF * 5f * Settings.LookSensitivity);
             Cam.GameObject.transform.eulerAngles = rot;
-             
+
             Input.MousePosition = WindowCenter.ToFloat().ToGeneric();
         } else {
             moveSpeed = 1;

--- a/Prowl.Editor/ImGUI/ImGUIController.cs
+++ b/Prowl.Editor/ImGUI/ImGUIController.cs
@@ -1,7 +1,7 @@
-﻿using HexaEngine.ImGuiNET;
-using HexaEngine.ImGuizmoNET;
-using HexaEngine.ImNodesNET;
-using HexaEngine.ImPlotNET;
+﻿using Hexa.NET.ImGui;
+using Hexa.NET.ImGuizmo;
+using Hexa.NET.ImNodes;
+using Hexa.NET.ImPlot;
 using Prowl.Icons;
 using Prowl.Runtime;
 using Silk.NET.Input;
@@ -55,7 +55,7 @@ namespace Prowl.Editor.ImGUI
         {
             Init(gl, view, input);
 
-            var io = ImGui.GetIO(); 
+            var io = ImGui.GetIO();
 
             using (Stream stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("Prowl.Editor.EmbeddedResources.font.ttf")) {
                 string tempFilePath = Path.Combine(Path.GetTempPath(), "font.ttf");

--- a/Prowl.Editor/ImGUI/Widgets/DragnDrop.cs
+++ b/Prowl.Editor/ImGUI/Widgets/DragnDrop.cs
@@ -1,4 +1,4 @@
-﻿using HexaEngine.ImGuiNET;
+﻿using Hexa.NET.ImGui;
 using Prowl.Runtime;
 
 namespace Prowl.Editor.ImGUI.Widgets

--- a/Prowl.Editor/ImGUI/Widgets/FileDialog.cs
+++ b/Prowl.Editor/ImGUI/Widgets/FileDialog.cs
@@ -1,4 +1,4 @@
-﻿using HexaEngine.ImGuiNET;
+﻿using Hexa.NET.ImGui;
 using System.Numerics;
 
 // Ported to c#: https://github.com/Limeoats/L2DFileDialog - Apache-2.0 license
@@ -74,7 +74,7 @@ namespace Prowl.Editor
         private static void Sort(ImFileDialogInfo dialogInfo, bool forceSort = false)
         {
             //var directories = dialogInfo.currentDirectories;
-            //var files = dialogInfo.currentFiles;            
+            //var files = dialogInfo.currentFiles;
             bool sort = false;
 
             if (fileNameSortOrderCopy != fileNameSortOrder)

--- a/Prowl.Editor/ImGUI/Widgets/GUIHelper.cs
+++ b/Prowl.Editor/ImGUI/Widgets/GUIHelper.cs
@@ -1,4 +1,4 @@
-﻿using HexaEngine.ImGuiNET;
+﻿using Hexa.NET.ImGui;
 using Prowl.Icons;
 using Prowl.Runtime;
 

--- a/Prowl.Editor/ImGUI/Widgets/ImFlameGraph.cs
+++ b/Prowl.Editor/ImGUI/Widgets/ImFlameGraph.cs
@@ -1,4 +1,4 @@
-﻿using HexaEngine.ImGuiNET;
+﻿using Hexa.NET.ImGui;
 using System.Numerics;
 using Prowl.Runtime;
 using Vector2 = Prowl.Runtime.Vector2;

--- a/Prowl.Editor/ImGUI/Widgets/Notifications.cs
+++ b/Prowl.Editor/ImGUI/Widgets/Notifications.cs
@@ -1,4 +1,4 @@
-﻿using HexaEngine.ImGuiNET;
+﻿using Hexa.NET.ImGui;
 using Prowl.Icons;
 using Prowl.Runtime;
 using System.Numerics;
@@ -157,12 +157,12 @@ namespace Prowl.Editor
                 ImGui.PushStyleColor(ImGuiCol.Text, textColor);
                 ImGui.SetNextWindowBgAlpha(opacity);
                 ImGui.SetNextWindowPos(new System.Numerics.Vector2(vp_size.X - NOTIFY_PADDING_X, vp_size.Y - NOTIFY_PADDING_Y - height), ImGuiCond.Always, new System.Numerics.Vector2(1.0f, 1.0f));
-                ImGui.Begin(windowName, 
-                    ImGuiWindowFlags.AlwaysAutoResize | 
-                    ImGuiWindowFlags.NoDecoration | 
-                    ImGuiWindowFlags.NoInputs | 
-                    ImGuiWindowFlags.NoNav | 
-                    //ImGuiWindowFlags.NoBringToFrontOnFocus | 
+                ImGui.Begin(windowName,
+                    ImGuiWindowFlags.AlwaysAutoResize |
+                    ImGuiWindowFlags.NoDecoration |
+                    ImGuiWindowFlags.NoInputs |
+                    ImGuiWindowFlags.NoNav |
+                    //ImGuiWindowFlags.NoBringToFrontOnFocus |
                     ImGuiWindowFlags.NoFocusOnAppearing |
                     ImGuiWindowFlags.Tooltip
                     );

--- a/Prowl.Editor/Prowl.Editor.csproj
+++ b/Prowl.Editor/Prowl.Editor.csproj
@@ -147,10 +147,10 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="HexaEngine.ImGui" Version="2.0.17" />
-      <PackageReference Include="HexaEngine.ImGuizmo" Version="2.0.17" />
-      <PackageReference Include="HexaEngine.ImNodes" Version="2.0.17" />
-      <PackageReference Include="HexaEngine.ImPlot" Version="2.0.17" />
+      <PackageReference Include="Hexa.NET.ImGui" Version="1.0.1" />
+      <PackageReference Include="Hexa.NET.ImGuizmo" Version="1.0.1" />
+      <PackageReference Include="Hexa.NET.ImNodes" Version="1.0.1" />
+      <PackageReference Include="Hexa.NET.ImPlot" Version="1.0.1" />
       <PackageReference Include="AssimpNet" Version="5.0.0-beta1" />
     </ItemGroup>
 

--- a/Prowl.Editor/Prowl.Editor.csproj
+++ b/Prowl.Editor/Prowl.Editor.csproj
@@ -147,10 +147,10 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Hexa.NET.ImGui" Version="1.0.1" />
-      <PackageReference Include="Hexa.NET.ImGuizmo" Version="1.0.1" />
-      <PackageReference Include="Hexa.NET.ImNodes" Version="1.0.1" />
-      <PackageReference Include="Hexa.NET.ImPlot" Version="1.0.1" />
+      <PackageReference Include="Hexa.NET.ImGui" Version="1.0.2" />
+      <PackageReference Include="Hexa.NET.ImGuizmo" Version="1.0.2" />
+      <PackageReference Include="Hexa.NET.ImNodes" Version="1.0.2" />
+      <PackageReference Include="Hexa.NET.ImPlot" Version="1.0.2" />
       <PackageReference Include="AssimpNet" Version="5.0.0-beta1" />
     </ItemGroup>
 

--- a/Prowl.Editor/SelectHandler.cs
+++ b/Prowl.Editor/SelectHandler.cs
@@ -1,4 +1,4 @@
-using HexaEngine.ImGuiNET;
+using Hexa.NET.ImGui;
 using Prowl.Runtime;
 
 namespace Prowl.Editor;

--- a/Prowl.Editor/Utilities/MenuItem.cs
+++ b/Prowl.Editor/Utilities/MenuItem.cs
@@ -1,4 +1,4 @@
-﻿using HexaEngine.ImGuiNET;
+﻿using Hexa.NET.ImGui;
 using System;
 using System.Reflection;
 


### PR DESCRIPTION
Switches obsolete packages for renamed ones. Allows building of `Prowl.Editor` on macOS. Still doesn't pen due to a failed GLFW assert.