### PR TITLE
File creation fixed (Issue  #103)

### DIFF
--- a/Prowl.Editor/EditorWindows/AssetBrowserWindow.cs
+++ b/Prowl.Editor/EditorWindows/AssetBrowserWindow.cs
@@ -12,7 +12,7 @@ public class AssetBrowserWindow : EditorWindow {
 
     public static EditorSettings Settings => Project.ProjectSettings.GetSetting<EditorSettings>();
 
-    public DirectoryInfo CurDirectory;
+    static public DirectoryInfo CurDirectory;
     public bool Locked = false;
 
     private string _searchText = "";

--- a/Prowl.Editor/EditorWindows/CreateNewFileWindow.cs
+++ b/Prowl.Editor/EditorWindows/CreateNewFileWindow.cs
@@ -24,7 +24,6 @@ public class CreateNewFileWindow : EditorWindow
     protected override bool BackgroundFade { get; } = true;
 
     DirectoryInfo? directory;
-    string fileType = "";
     Action<string, string> fileAction;
 
     public CreateNewFileWindow(DirectoryInfo? directory , Action<string, string> fileAction) : base()

--- a/Prowl.Editor/EditorWindows/MainMenuItems.cs
+++ b/Prowl.Editor/EditorWindows/MainMenuItems.cs
@@ -16,7 +16,7 @@ namespace Prowl.Editor.EditorWindows
         [MenuItem("Create/Folder")]
         public static void CreateFolder()
         {
-            Directory ??= new DirectoryInfo(Project.ProjectAssetDirectory);
+            Directory ??= AssetBrowserWindow.CurDirectory;
             var folderAction = new Action<string, string>((directory, createName) =>
             {
                 DirectoryInfo dir = new DirectoryInfo(Path.Combine(directory, createName));
@@ -32,7 +32,7 @@ namespace Prowl.Editor.EditorWindows
         [MenuItem("Create/Material")]
         public static void CreateMaterial()
         {
-            Directory ??= new DirectoryInfo(Project.ProjectAssetDirectory);
+            Directory ??= AssetBrowserWindow.CurDirectory;
             var materialAction = new Action<string, string>((directory, createName) =>
             {
                 Material mat = new Material(Shader.Find("Defaults/Standard.shader"));
@@ -53,7 +53,7 @@ namespace Prowl.Editor.EditorWindows
         [MenuItem("Create/Script")]
         public static void CreateScript()
         {
-            Directory ??= new DirectoryInfo(Project.ProjectAssetDirectory);
+            Directory ??= AssetBrowserWindow.CurDirectory;
             var scriptAction = new Action<string, string>((directory, createName) =>
             {
                 FileInfo file = new FileInfo(Path.Combine(directory, $"{createName}.cs"));


### PR DESCRIPTION
### Fix to the problem where the files were being created only at the root folder instead of the desired one (Issue #103 )

https://github.com/michaelsakharov/Prowl/assets/23508114/8ba3b94d-ce69-4880-802a-e70ce10895cd

I made the CurDirectory variable from the AssetBrowserWindow.cs static in order to indicate the path where the file will be created in MainMenuItems.cs