### PR TITLE
Build fixes

### DIFF
--- a/Prowl.Editor/Assets/AssetDatabase.Utilities.cs
+++ b/Prowl.Editor/Assets/AssetDatabase.Utilities.cs
@@ -3,6 +3,8 @@
 
 using System.Diagnostics;
 
+using CommandLine.Text;
+
 using Prowl.Runtime;
 
 namespace Prowl.Editor.Assets;
@@ -277,6 +279,22 @@ public static partial class AssetDatabase
             return result;
         }
         return [];
+    }
+
+    public static bool GetDefaultAssets(out List<Guid> guids)
+    {
+        guids = new List<Guid>();
+        if (Project.Active == null)
+            return false;
+
+        foreach (FileInfo fileInfo in Project.Active?.DefaultsDirectory.EnumerateFiles())
+        {
+            MetaFile? meta = MetaFile.Load(fileInfo);
+
+            if (meta != null)
+                guids.Add(meta.guid);
+        }
+        return true;
     }
 
     #endregion

--- a/Prowl.Editor/Build/DesktopPlayerBuilder.cs
+++ b/Prowl.Editor/Build/DesktopPlayerBuilder.cs
@@ -261,13 +261,24 @@ public class Desktop_Player : ProjectBuilder
         }
         else
         {
+            // This is missing the skybox asset (and possibly other defaults)
+
             HashSet<Guid> assets = [];
             foreach (AssetRef<Scene> scene in scenes)
+            {
                 AssetDatabase.GetDependenciesDeep(scene.AssetID, ref assets);
+            }
+            if (AssetDatabase.GetDefaultAssets(out List<Guid> guids))
+            {
+                foreach (Guid assetID in guids)
+                    assets.Add(assetID);
+            }
+
+            // Get assets from /Defaults dir too
 
             // Include all Shaders in the build for the time being
-            foreach ((string, Guid, ushort) shader in AssetDatabase.GetAllAssetsOfType<Shader>())
-                assets.Add(shader.Item2);
+            foreach ((string name, Guid assetID, ushort fileId) shader in AssetDatabase.GetAllAssetsOfType<Shader>())
+                assets.Add(shader.assetID);
 
             AssetDatabase.ExportBuildPackages(assets.ToArray(), new DirectoryInfo(dataPath));
         }

--- a/Prowl.Editor/Editor/BuildWindow.cs
+++ b/Prowl.Editor/Editor/BuildWindow.cs
@@ -77,6 +77,8 @@ public class BuildWindow : EditorWindow
 
                 // Name types are formatted as "Desktop_Player" -> "Desktop"
                 string name = builder.GetType().Name;
+
+                // Make sure name does actually include underscore
                 int underscoreIndex = name.IndexOf('_');
                 if (underscoreIndex > 0)
                     name = name.Substring(0, underscoreIndex);

--- a/Prowl.Editor/Editor/BuildWindow.cs
+++ b/Prowl.Editor/Editor/BuildWindow.cs
@@ -77,7 +77,9 @@ public class BuildWindow : EditorWindow
 
                 // Name types are formatted as "Desktop_Player" -> "Desktop"
                 string name = builder.GetType().Name;
-                name = name.Substring(0, name.IndexOf('_'));
+                int underscoreIndex = name.IndexOf('_');
+                if (underscoreIndex > 0)
+                    name = name.Substring(0, underscoreIndex);
                 gui.Draw2D.DrawText(name, gui.CurrentNode.LayoutData.InnerRect);
             }
         }

--- a/Prowl.Editor/Editor/ProjectsWindow.cs
+++ b/Prowl.Editor/Editor/ProjectsWindow.cs
@@ -252,7 +252,7 @@ public class ProjectsWindow : EditorWindow
         // Text pos + offset/padding
         Vector2 openInfoTextPos = footer.Position + new Vector2(8f, 8f);
         gui.Draw2D.DrawText($"Opening '{SelectedProject.Name}'...", openInfoTextPos);
-        
+
         // Add more information about progress here (even console output)
 
         // Cover controls (fill EditorWindow)
@@ -393,6 +393,7 @@ public class ProjectsWindow : EditorWindow
     }
 
     Project contextMenuProject = null;
+    bool contextMenuIsHovered = false;
     private void DisplayProject(Project project)
     {
         Rect rootRect = gui.CurrentNode.LayoutData.Rect;
@@ -465,6 +466,7 @@ public class ProjectsWindow : EditorWindow
                 {
                     gui.Draw2D.DrawRectFilled(rect, EditorStylePrefs.Instance.Highlighted, (float)EditorStylePrefs.Instance.WindowRoundness, CornerRounding.All);
                     contextMenuProject = project;
+                    contextMenuIsHovered = false;
                     gui.OpenPopup("ProjectOptionsContextMenu", null, gui.CurrentNode.Parent);
                 }
                 else if (optionsInteract.IsHovered())
@@ -490,8 +492,21 @@ public class ProjectsWindow : EditorWindow
         {
             using (popupHolder.Width(180).Padding(5).Layout(LayoutType.Column).Spacing(5).FitContentHeight().Enter())
             {
+                // Getting Interactable (IsHovered) removes interaction from styled buttons?
+                if (popupHolder.LayoutData.Rect.Contains(gui.PointerPos))
+                {
+                    if (!contextMenuIsHovered)
+                        contextMenuIsHovered = true;
+                }
+                else
+                {
+                    if (contextMenuIsHovered)
+                        closePopup = true;
+                }
+
                 // Add options
                 // - Delete project (with popup confirmation)
+
                 if (EditorGUI.StyledButton("Show In Explorer"))
                 {
                     AssetDatabase.OpenPath(project.ProjectDirectory, type: FileOpenType.FileExplorer);
@@ -502,6 +517,8 @@ public class ProjectsWindow : EditorWindow
                     ProjectCache.Instance.RemoveProject(project);
                     closePopup = true;
                 }
+
+              
             }
         }
         if (closePopup)

--- a/Prowl.Editor/Editor/ProjectsWindow.cs
+++ b/Prowl.Editor/Editor/ProjectsWindow.cs
@@ -249,6 +249,10 @@ public class ProjectsWindow : EditorWindow
         // Display load info (and possibly load bar). Placed in empty space of footer
 
         // Opening project info
+
+        // Projects list clips overlay. Ignore clipping
+        gui.Draw2D.PushClip(gui.ScreenRect, true);
+
         // Text pos + offset/padding
         Vector2 openInfoTextPos = footer.Position + new Vector2(8f, 8f);
         gui.Draw2D.DrawText($"Opening '{SelectedProject.Name}'...", openInfoTextPos);
@@ -256,16 +260,17 @@ public class ProjectsWindow : EditorWindow
         // Add more information about progress here (even console output)
 
         // Cover controls (fill EditorWindow)
-        gui.Draw2D.DrawRectFilled(this.Rect, GrayAlpha);
+        gui.Draw2D.DrawRectFilled(gui.ScreenRect, GrayAlpha);
 
+        gui.Draw2D.PopClip();
 
         // Redirect output of logs to window
-        Debug.OnLog += OpeningProjectLog;
+        //Debug.OnLog += OpeningProjectLog;
 
-        // Should probably occur on a new thread to stop blocking UI
+        // Should probably occur on a new thread/async to stop blocking UI
         bool projectOpened = Project.Open(SelectedProject);
 
-        Debug.OnLog -= OpeningProjectLog;
+       // Debug.OnLog -= OpeningProjectLog;
         if (projectOpened)
             isOpened = false;
     }
@@ -518,7 +523,7 @@ public class ProjectsWindow : EditorWindow
                     closePopup = true;
                 }
 
-              
+
             }
         }
         if (closePopup)

--- a/Prowl.Editor/Project/DotnetCompileOptions.cs
+++ b/Prowl.Editor/Project/DotnetCompileOptions.cs
@@ -19,6 +19,7 @@ public struct DotnetCompileOptions()
     public DirectoryInfo? outputPath = null;
     public DirectoryInfo? tempPath = null;
 
+    public Dictionary<string, string> additionalParameters = new Dictionary<string, string>();
 
     public string ConstructDotnetArgs(FileInfo project)
     {
@@ -84,6 +85,14 @@ public struct DotnetCompileOptions()
                 Platform.Windows => "win",
                 _ => throw new Exception($"Unknown target platform: {platform}")
             });
+        }
+
+        if (additionalParameters.Count > 0)
+        {
+            foreach (KeyValuePair<string, string> kvp in additionalParameters)
+            {
+                args.Add($"/p:{kvp.Key}={kvp.Value}");
+            }
         }
 
         return string.Join(" ", args);

--- a/Prowl.Runtime/GUI/Layout/LayoutNode.API.cs
+++ b/Prowl.Runtime/GUI/Layout/LayoutNode.API.cs
@@ -172,7 +172,8 @@ public partial class LayoutNode
         if (Parent != null)
             Parent.Children.Remove(this);
         Parent = newParent;
-        Parent.Children.Add(this);
+        if (Parent != null)
+            Parent.Children.Add(this);
         //Parent.GetNextNode();
         _positionRelativeTo = newParent;
         _sizeRelativeTo = newParent;


### PR DESCRIPTION
- Fixed BuildWindow crash due to substring name missing char
- Added `GetDefaultAssets` function to `AssetDatabaseUtils`
- Added default assets to be packed in Desktop compilation. Fixes building projects that use default assets and had asset packing set to 'used assets'
- Uniformity on project window loading overlay (doubleclicking project now does same action as clicking 'open' button)