### PR TITLE
Added Primitives class

### DIFF
--- a/Prowl.Runtime/Primitives.cs
+++ b/Prowl.Runtime/Primitives.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.CompilerServices;
 using Prowl.Runtime.Resources;
 using Prowl.Vector;
@@ -9,28 +10,53 @@ public static class Primitives
     private static Material _standardMaterial;
     private static Mesh _cubeMesh;
     private static Mesh _cylinderMesh;
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static GameObject Cube(string name, Double3 size)
+    public static GameObject Cube(string name)
     {
         _standardMaterial ??= new Material(Shader.LoadDefault(DefaultShader.Standard));
         _cubeMesh ??= Mesh.CreateCube(Double3.One);
-        return Cube(name, size, _standardMaterial, _cubeMesh);
+        return Cube(name, Double3.Zero, Double3.One, _standardMaterial, _cubeMesh);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static GameObject Cube(string name, Double3 size, Material material)
+    public static GameObject Cube(Double3 position)
+    {
+        _standardMaterial ??= new Material(Shader.LoadDefault(DefaultShader.Standard));
+        _cubeMesh ??= Mesh.CreateCube(Double3.One);
+        return Cube(position.ToString(), position, Double3.One, _standardMaterial, _cubeMesh);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static GameObject Cube(string name, Double3 position)
+    {
+        _standardMaterial ??= new Material(Shader.LoadDefault(DefaultShader.Standard));
+        _cubeMesh ??= Mesh.CreateCube(Double3.One);
+        return Cube(name, position, Double3.One, _standardMaterial, _cubeMesh);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static GameObject Cube(string name, Double3 position, Double3 scale)
+    {
+        _standardMaterial ??= new Material(Shader.LoadDefault(DefaultShader.Standard));
+        _cubeMesh ??= Mesh.CreateCube(Double3.One);
+        return Cube(name, position, scale, _standardMaterial, _cubeMesh);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static GameObject Cube(string name, Double3 position, Double3 scale, Material material)
     {
         _cubeMesh ??= Mesh.CreateCube(Double3.One);
-        return Cube(name, size, material, _cubeMesh);
+        return Cube(name, scale, position, material, _cubeMesh);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static GameObject Cube(string name, Double3 size, Material material, Mesh mesh)
+    public static GameObject Cube(string name, Double3 position, Double3 scale, Material material, Mesh mesh)
     {
         // game object
         var go = new GameObject(name);
-        go.Transform.localScale = size;
+        go.Transform.position = position;
+        go.Transform.localScale = scale;
 
         // visuals
         var ren = go.AddComponent<MeshRenderer>();
@@ -41,25 +67,50 @@ public static class Primitives
     }
     
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static GameObject PhysicsCube(string name, Double3 size, bool isStatic = false)
+    public static GameObject PhysicsCube(string name, bool isStatic = false)
     {
         _standardMaterial ??= new Material(Shader.LoadDefault(DefaultShader.Standard));
         _cubeMesh ??= Mesh.CreateCube(Double3.One);
-        return PhysicsCube(name, size, _standardMaterial, _cubeMesh, isStatic);
+        return PhysicsCube(name, Double3.Zero, Double3.One, _standardMaterial, _cubeMesh, isStatic);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static GameObject PhysicsCube(string name, Double3 size, Material material, bool isStatic = false)
+    public static GameObject PhysicsCube(Double3 position, bool isStatic = false)
+    {
+        _standardMaterial ??= new Material(Shader.LoadDefault(DefaultShader.Standard));
+        _cubeMesh ??= Mesh.CreateCube(Double3.One);
+        return PhysicsCube(position.ToString(), position, Double3.One, _standardMaterial, _cubeMesh, isStatic);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static GameObject PhysicsCube(string name, Double3 position, bool isStatic = false)
+    {
+        _standardMaterial ??= new Material(Shader.LoadDefault(DefaultShader.Standard));
+        _cubeMesh ??= Mesh.CreateCube(Double3.One);
+        return PhysicsCube(name, position, Double3.One, _standardMaterial, _cubeMesh, isStatic);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static GameObject PhysicsCube(string name, Double3 position, Double3 size, bool isStatic = false)
+    {
+        _standardMaterial ??= new Material(Shader.LoadDefault(DefaultShader.Standard));
+        _cubeMesh ??= Mesh.CreateCube(Double3.One);
+        return PhysicsCube(name, position, size, _standardMaterial, _cubeMesh, isStatic);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static GameObject PhysicsCube(string name, Double3 position, Double3 size, Material material, bool isStatic = false)
     {
         _cubeMesh ??= Mesh.CreateCube(Double3.One);
-        return PhysicsCube(name, size, material, _cubeMesh, isStatic);
+        return PhysicsCube(name, position, size, material, _cubeMesh, isStatic);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static GameObject PhysicsCube(string name, Double3 size, Material material, Mesh mesh, bool isStatic = false)
+    public static GameObject PhysicsCube(string name, Double3 position, Double3 size, Material material, Mesh mesh, bool isStatic = false)
     {
         // game object
         var go = new GameObject(name);
+        go.Transform.position = position;
         go.Transform.localScale = size;
 
         // visuals

--- a/Prowl.Runtime/Primitives.cs
+++ b/Prowl.Runtime/Primitives.cs
@@ -15,26 +15,18 @@ public static class Primitives
     {
         _standardMaterial ??= new Material(Shader.LoadDefault(DefaultShader.Standard));
         _cubeMesh ??= Mesh.CreateCube(Double3.One);
-
-        // game object
-        var (go, ren) = Cube(name, size, _standardMaterial, _cubeMesh);
-
-        return go;
+        return Cube(name, size, _standardMaterial, _cubeMesh);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static GameObject Cube(string name, Double3 size, Material material)
     {
         _cubeMesh ??= Mesh.CreateCube(Double3.One);
-
-        // game object
-        var (go, ren) = Cube(name, size, material, _cubeMesh);
-
-        return go;
+        return Cube(name, size, material, _cubeMesh);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static (GameObject, MeshRenderer) Cube(string name, Double3 size, Material material, Mesh mesh)
+    public static GameObject Cube(string name, Double3 size, Material material, Mesh mesh)
     {
         // game object
         var go = new GameObject(name);
@@ -45,7 +37,7 @@ public static class Primitives
         ren.Mesh = mesh;
         ren.Material = material;
 
-        return (go, ren);
+        return go;
     }
     
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -53,28 +45,18 @@ public static class Primitives
     {
         _standardMaterial ??= new Material(Shader.LoadDefault(DefaultShader.Standard));
         _cubeMesh ??= Mesh.CreateCube(Double3.One);
-
-        // game object
-        var (go, ren, rb, col) = PhysicsCube(name, size, _standardMaterial, _cubeMesh, isStatic);
-        rb.IsStatic = isStatic;
-
-        return go;
+        return PhysicsCube(name, size, _standardMaterial, _cubeMesh, isStatic);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static GameObject PhysicsCube(string name, Double3 size, Material material, bool isStatic = false)
     {
         _cubeMesh ??= Mesh.CreateCube(Double3.One);
-
-        // game object
-        var (go, ren, rb, col) = PhysicsCube(name, size, material, _cubeMesh, isStatic);
-        rb.IsStatic = isStatic;
-
-        return go;
+        return PhysicsCube(name, size, material, _cubeMesh, isStatic);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static (GameObject, MeshRenderer, Rigidbody3D, BoxCollider) PhysicsCube(string name, Double3 size, Material material, Mesh mesh, bool isStatic = false)
+    public static GameObject PhysicsCube(string name, Double3 size, Material material, Mesh mesh, bool isStatic = false)
     {
         // game object
         var go = new GameObject(name);
@@ -91,6 +73,6 @@ public static class Primitives
         var col = go.AddComponent<BoxCollider>();
         // col.Size = size; // <- boxCollider is scaled with gameobject, no need to scale it here
 
-        return (go, ren, rb, col);
+        return go;
     }
 }

--- a/Prowl.Runtime/Primitives.cs
+++ b/Prowl.Runtime/Primitives.cs
@@ -1,0 +1,96 @@
+using System.Runtime.CompilerServices;
+using Prowl.Runtime.Resources;
+using Prowl.Vector;
+
+namespace Prowl.Runtime;
+
+public static class Primitives
+{
+    private static Material _standardMaterial;
+    private static Mesh _cubeMesh;
+    private static Mesh _cylinderMesh;
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static GameObject Cube(string name, Double3 size)
+    {
+        _standardMaterial ??= new Material(Shader.LoadDefault(DefaultShader.Standard));
+        _cubeMesh ??= Mesh.CreateCube(Double3.One);
+
+        // game object
+        var (go, ren) = Cube(name, size, _standardMaterial, _cubeMesh);
+
+        return go;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static GameObject Cube(string name, Double3 size, Material material)
+    {
+        _cubeMesh ??= Mesh.CreateCube(Double3.One);
+
+        // game object
+        var (go, ren) = Cube(name, size, material, _cubeMesh);
+
+        return go;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static (GameObject, MeshRenderer) Cube(string name, Double3 size, Material material, Mesh mesh)
+    {
+        // game object
+        var go = new GameObject(name);
+        go.Transform.localScale = size;
+
+        // visuals
+        var ren = go.AddComponent<MeshRenderer>();
+        ren.Mesh = mesh;
+        ren.Material = material;
+
+        return (go, ren);
+    }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static GameObject PhysicsCube(string name, Double3 size, bool isStatic = false)
+    {
+        _standardMaterial ??= new Material(Shader.LoadDefault(DefaultShader.Standard));
+        _cubeMesh ??= Mesh.CreateCube(Double3.One);
+
+        // game object
+        var (go, ren, rb, col) = PhysicsCube(name, size, _standardMaterial, _cubeMesh, isStatic);
+        rb.IsStatic = isStatic;
+
+        return go;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static GameObject PhysicsCube(string name, Double3 size, Material material, bool isStatic = false)
+    {
+        _cubeMesh ??= Mesh.CreateCube(Double3.One);
+
+        // game object
+        var (go, ren, rb, col) = PhysicsCube(name, size, material, _cubeMesh, isStatic);
+        rb.IsStatic = isStatic;
+
+        return go;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static (GameObject, MeshRenderer, Rigidbody3D, BoxCollider) PhysicsCube(string name, Double3 size, Material material, Mesh mesh, bool isStatic = false)
+    {
+        // game object
+        var go = new GameObject(name);
+        go.Transform.localScale = size;
+
+        // visuals
+        var ren = go.AddComponent<MeshRenderer>();
+        ren.Mesh = mesh;
+        ren.Material = material;
+
+        // physics
+        var rb = go.AddComponent<Rigidbody3D>();
+        rb.IsStatic = isStatic;
+        var col = go.AddComponent<BoxCollider>();
+        // col.Size = size; // <- boxCollider is scaled with gameobject, no need to scale it here
+
+        return (go, ren, rb, col);
+    }
+}


### PR DESCRIPTION
```cs
// create a ground cube with physics and colliders
var groundGo = Primitives.PhysicsCube("Ground", new Double3(20, 1, 200), isStatic: true);
scene.Add(groundGo);

// you can also create non physics primitives
var regularCube = Primitives.Cube("My cube", Double.One);
scene.Add(regularCube);

// provide your own material
var mat = new Material(Shader.LoadDefault(ShaderDefaults.Standard);
scene.Add(Primitives.Cube("My cube 2", Double.One, mat);

// provide your own mesh
var mesh = Mesh.CreateCube(Double.One);
scene.Add(Primitives.Cube("My cube 3", Double.One, mat, mesh);
```

Also automatically uses a cached mesh/material if you don't provide one :)