### PR TITLE
Fixed bug with Raycast

### DIFF
--- a/Prowl.Runtime/Physics/RaycastHit.cs
+++ b/Prowl.Runtime/Physics/RaycastHit.cs
@@ -64,6 +64,6 @@ public struct RaycastHit
         Transform = Rigidbody?.GameObject?.Transform;
         Normal = new Double3(result.Normal.X, result.Normal.Y, result.Normal.Z);
         Distance = result.Lambda;
-        Point = origin + direction * Distance;
+        Point = origin + (direction * Distance);
     }
 }


### PR DESCRIPTION

https://github.com/user-attachments/assets/f7f36c0b-b668-4fb3-94ef-c1dad5734782

The math inside of SetFromJitterResult just needed () around the multiplication 😄 

```diff
internal void SetFromJitterResult(DynamicTree.RayCastResult result, Double3 origin, Double3 direction)
{
    Shape = result.Entity as RigidBodyShape;
    if (Shape == null)
    {
        Hit = false;
        return;
    }

    var userData = Shape.RigidBody.Tag as Rigidbody3D.RigidBodyUserData;

    Hit = true;
    Rigidbody = userData.Rigidbody;
    Transform = Rigidbody?.GameObject?.Transform;
    Normal = new Double3(result.Normal.X, result.Normal.Y, result.Normal.Z);
    Distance = result.Lambda;
-    Point = origin + direction * Distance;
+    Point = origin + (direction * Distance);
}
```