### PR TITLE
Allow for removing component if there are multiple of the same type on an object.

### DIFF
--- a/Prowl.Runtime/GameObject/GameObject.cs
+++ b/Prowl.Runtime/GameObject/GameObject.cs
@@ -875,10 +875,19 @@ public class GameObject : EngineObject, ISerializable, ICloneExplicit
     internal bool IsComponentRequired(MonoBehaviour requiredComponent, out Type dependentType)
     {
         Type componentType = requiredComponent.GetType();
+
+        // Check if there is multiple of the same type before checking if required.
+        int numType = _components.Count(x => x.GetType() == componentType);
+        if (numType > 1)
+        {
+            dependentType = null;
+            return false;
+        }
+
+        // If it is the last type on a GameObject, check if it is required by another component.
         foreach (MonoBehaviour component in _components)
         {
-            RequireComponentAttribute? requireComponentAttribute =
-                component.GetType().GetCustomAttribute<RequireComponentAttribute>();
+            RequireComponentAttribute? requireComponentAttribute = component.GetType().GetCustomAttribute<RequireComponentAttribute>();
             if (requireComponentAttribute == null)
                 continue;
 


### PR DESCRIPTION
I ran into an issue where I could not remove a component because it was required, but there were multiple of the same required type on the GameObject. This makes it so it will only run the check on the required type if the `last` component of a certain type is being removed.