### PR TITLE
Console Panel Polish and adjustments, ContextMenuBuilder additional h…

### DIFF
--- a/Prowl.Editor/MainMenuBar.cs
+++ b/Prowl.Editor/MainMenuBar.cs
@@ -133,11 +133,13 @@ public static class MainMenuBar
                     {
                         paper.Box($"{id}_chk_{index}")
                             .Width(24)
+                            .Alignment(TextAlignment.MiddleLeft)
                             .Text(item.IsChecked ? "\u2713" : "", font)
                             .TextColor(textColor)
                             .FontSize(EditorTheme.FontSize);
 
                         paper.Box($"{id}_lbl_{index}")
+                            .Alignment(TextAlignment.MiddleLeft)
                             .Text(displayLabel, font)
                             .TextColor(textColor)
                             .FontSize(EditorTheme.FontSize);
@@ -150,6 +152,7 @@ public static class MainMenuBar
                         {
                             paper.Box($"{id}_arr_{index}")
                                 .Width(20)
+                                .Alignment(TextAlignment.MiddleLeft)
                                 .Margin(0, 4, 0, 0)
                                 .Text("\u25B6", font)
                                 .TextColor(textColor)

--- a/Prowl.Editor/Panels/ConsolePanel.cs
+++ b/Prowl.Editor/Panels/ConsolePanel.cs
@@ -21,14 +21,23 @@ public class ConsolePanel : DockPanel
 
     private const float ToolbarHeight = 26f;
     private const int MaxMessages = 500;
-    private const float RowHeight = 20f;
-    private const float IconWidth = 14f;
-    private const float TimeWidth = 52f;
+
+    private float FullRowHeight => _multiLine ? MultiLineRowHeight : RowHeight;
+
+    private float RowHeight = 26f;
+    private float MultiLineRowHeight => RowHeight * 1.8f;
+    private const float IconWidth = 16f;
+    private float TimeWidth => 68f;
     private const float CountWidth = 30f;
-    private const float FontSize = 10f;
+    private const float FontSize = 13f;
 
     private static readonly List<LogEntry> _messages = new();
     private static bool _subscribed;
+
+    // Settings
+    private bool _showTime = false;
+    private bool _collapse = true;
+    private bool _multiLine = false;
 
     // Filters
     private bool _showInfo = true;
@@ -39,6 +48,7 @@ public class ConsolePanel : DockPanel
     // Cached filtered list (rebuilt when messages or filters change)
     private static int _lastMessageCount;
     private static int _lastFilterHash;
+    private static bool _lastCollapseState;
     private static readonly List<int> _filteredIndices = new();
 
 
@@ -111,10 +121,12 @@ public class ConsolePanel : DockPanel
         var font = EditorTheme.DefaultFont;
         if (font == null) return;
 
-        using (paper.Column("con_root").Size(width, height).Enter())
+        using (paper.Column("con_root")
+            .Size(width, height)
+            .Enter())
         {
             DrawToolbar(paper, font, width);
-            DrawMessages(paper, font, width, height - 33);
+            DrawMessages(paper, font, width-2, height - 44);
         }
     }
 
@@ -123,13 +135,14 @@ public class ConsolePanel : DockPanel
         using (paper.Row("con_toolbar")
             .Height(ToolbarHeight)
             .Margin(4, 4, 4, 0)
-            .RowBetween(4)
+            .RowBetween(12)
+            .Margin(8)
             .Enter())
         {
             EditorGUI.Button(paper, "con_clear", "Clear", width: 50)
                 .OnValueChanged(_ => { _messages.Clear(); _filteredIndices.Clear(); });
 
-            paper.Box("con_sep1").Width(1).Height(20).BackgroundColor(EditorTheme.Ink200);
+            paper.Box("con_sep1").Width(1).Height(24).BackgroundColor(EditorTheme.Ink200);
 
             int infoCount = 0, warnCount = 0, errCount = 0;
             foreach (var m in _messages)
@@ -139,18 +152,54 @@ public class ConsolePanel : DockPanel
                 else errCount += m.Count;
             }
 
-            using (paper.Row("buttons").Enter())
+            EditorGUI.ToggleButton(paper, "con_collapse", "Collapse", _collapse, fitWidth: true).OnValueChanged(newValue =>
             {
-                EditorGUI.ToggleButton(paper, "con_info", $"{EditorIcons.CircleInfo} {infoCount}", _showInfo)
+                _collapse = newValue;
+            });
+
+            using (paper.Row("buttons")
+                .RowBetween(8)
+                .Enter())
+            {
+                GetToggleStyle(LogSeverity.Normal, out Color infoTextColor, out Color infoBgColor);
+                EditorGUI.ToggleButton(paper, "con_info", $"{EditorIcons.CircleInfo} {infoCount}", _showInfo,
+                    fitWidth: true, textColorOverride: _showInfo ? infoTextColor : EditorTheme.Ink300, bgColorOverride: infoBgColor)
                     .OnValueChanged(v => _showInfo = v);
-                EditorGUI.ToggleButton(paper, "con_warn", $"{EditorIcons.TriangleExclamation} {warnCount}", _showWarnings)
+
+                GetToggleStyle(LogSeverity.Warning, out Color warnTextColor, out Color warnBgColor);
+                EditorGUI.ToggleButton(paper, "con_warn", $"{EditorIcons.TriangleExclamation} {warnCount}", _showWarnings,
+                    fitWidth: true, textColorOverride: _showWarnings ? warnTextColor : EditorTheme.Ink300, bgColorOverride: warnBgColor)
                     .OnValueChanged(v => _showWarnings = v);
-                EditorGUI.ToggleButton(paper, "con_err", $"{EditorIcons.CircleExclamation} {errCount}", _showErrors)
+
+                GetToggleStyle(LogSeverity.Error, out Color errorTextColor, out Color errorBgColor);
+                EditorGUI.ToggleButton(paper, "con_err", $"{EditorIcons.CircleExclamation} {errCount}", _showErrors,
+                    fitWidth: true, textColorOverride: _showErrors ? errorTextColor : EditorTheme.Ink300, bgColorOverride: errorBgColor)
                     .OnValueChanged(v => _showErrors = v);
             }
 
             EditorGUI.SearchBar(paper, "con_search", _searchText, "Filter...")
                 .OnValueChanged(v => _searchText = v);
+
+            EditorGUI.ButtonSquareWithHandle(paper, "con_settingsButton", $"{EditorIcons.Gear}", out var settingsButton)
+                .OnValueChanged((clicked) =>
+                {
+                    ContextMenuHelper.OpenContextMenu(paper, "con_settings", settingsButton);
+                });
+
+            ContextMenuHelper.ContextMenu(paper, "con_settings", menu =>
+            {
+                menu.Submenu("Log Tests", (subMenu) =>
+                {
+                    subMenu.Item("Log", () => Debug.Log($"This is a Normal Log."))
+                    .Item("LogWarning", () => Debug.LogWarning($"This is a Warning Log."))
+                    .Item("LogError", () => Debug.LogError($"This is an Error Log."))
+                    .Item("LogSuccess", () => Debug.LogSuccess($"This is a Success Log."));
+                }, EditorIcons.Flask)
+                .Separator()
+                .Toggle("Show Time", () => _showTime = !_showTime, () => _showTime)
+                .Toggle("Multi Line", () => _multiLine = !_multiLine, () => _multiLine)
+                ;
+            }, settingsButton);
         }
     }
 
@@ -158,27 +207,31 @@ public class ConsolePanel : DockPanel
     {
         // Rebuild filtered list when needed
         int filterHash = HashCode.Combine(_showInfo, _showWarnings, _showErrors, _searchText);
-        if (_lastMessageCount != _messages.Count || _lastFilterHash != filterHash)
+        if (_lastMessageCount != _messages.Count || _lastFilterHash != filterHash || _lastCollapseState != _collapse)
         {
             _lastMessageCount = _messages.Count;
             _lastFilterHash = filterHash;
+            _lastCollapseState = _collapse;
             RebuildFilteredList();
         }
 
         int visibleCount = _filteredIndices.Count;
-        float totalContentHeight = visibleCount * RowHeight;
+        float totalContentHeight = visibleCount * FullRowHeight;
 
-        using (ScrollView.Begin(paper, "con_scroll", width, height))
+        using (ScrollView.Begin(paper, "con_scroll", width, height, forceScrollbar:true))
         {
             // Single element for ALL messages — fixed height based on count
             paper.Box("con_content")
-                .Width(width)
+                .Width(width - 10)
                 .Height(totalContentHeight)
+                .BackgroundColor(EditorTheme.Neutral100)
+                .Clip()
                 .OnClick(0, (_, e) =>
                 {
                     // Determine clicked row from mouse Y relative to content
                     float relY = (float)e.RelativePosition.Y;
-                    int clickedRow = (int)(relY / RowHeight);
+                    float totalRowHeight = FullRowHeight;
+                    int clickedRow = (int)(relY / totalRowHeight);
                     if (clickedRow >= 0 && clickedRow < _filteredIndices.Count)
                     {
                         _selectedFilteredIndex = (_selectedFilteredIndex == clickedRow) ? -1 : clickedRow;
@@ -207,13 +260,14 @@ public class ConsolePanel : DockPanel
                     float contentTop = (float)contentRect.Min.Y;
 
                     // Calculate visible row range
-                    int firstVisible = Math.Max(0, (int)((clipTop - contentTop) / RowHeight));
-                    int lastVisible = Math.Min(visibleCount - 1, (int)((clipBottom - contentTop) / RowHeight));
+                    int firstVisible = Math.Max(0, (int)((clipTop - contentTop) / FullRowHeight));
+                    int lastVisible = Math.Min(visibleCount - 1, (int)((clipBottom - contentTop) / FullRowHeight));
 
                     // Draw all visible rows in one draw call using cached TextLayouts
                     paper.Draw(ref handle, (canvas, r) =>
                     {
                         float startX = (float)r.Min.X;
+                        float paddedX = startX + 8;
                         float startY = (float)r.Min.Y;
                         float size = FontSize * 1.5f;
 
@@ -223,38 +277,62 @@ public class ConsolePanel : DockPanel
                             int msgIdx = _filteredIndices[vi];
                             if (msgIdx >= _messages.Count) continue;
 
+                            var totalRowSize = FullRowHeight;
+
                             var msg = _messages[msgIdx];
-                            float rowY = startY + vi * RowHeight;
-                            float textY = rowY + RowHeight * 0.5f - size * 0.5f;
+                            float rowY = startY + vi * totalRowSize;
+                            float textY = rowY + totalRowSize * (_multiLine ? 0.25f : 0.5f) - size * 0.5f + 2;
+                            float iconY = rowY + totalRowSize * 0.5f - size * 0.5f;
 
                             GetEntryStyle(msg.Severity, vi, out string icon, out Color textColor, out Color bgColor);
 
                             // Selection highlight
                             if (vi == _selectedFilteredIndex)
-                                canvas.RectFilled(startX, rowY, (float)r.Size.X, RowHeight, Color.FromArgb(60, EditorTheme.Purple400));
+                                canvas.RectFilled(startX, rowY, (float)r.Size.X, totalRowSize, Color.FromArgb(60, EditorTheme.Purple400));
                             else if (bgColor != Color.Transparent)
-                                canvas.RectFilled(startX, rowY, (float)r.Size.X, RowHeight, bgColor);
+                                canvas.RectFilled(startX, rowY, (float)r.Size.X, totalRowSize, bgColor);
+
+                            canvas.RectFilled(startX+2, rowY+1, (float)4, totalRowSize-2, EditorGUI.LerpRGB(textColor, Color.Black, 0.5f));
 
                             // Create layouts lazily
                             msg.IconLayout ??= canvas.CreateLayout(icon, new Prowl.Scribe.TextLayoutSettings { Font = font, PixelSize = size });
                             msg.TimeLayout ??= canvas.CreateLayout(msg.TimeString, new Prowl.Scribe.TextLayoutSettings { Font = font, PixelSize = size });
                             msg.MessageLayout ??= canvas.CreateLayout(msg.Message, new Prowl.Scribe.TextLayoutSettings { Font = font, PixelSize = size });
 
+
+                            float padStack = 4;
                             // Draw using cached layouts
-                            canvas.DrawLayout(msg.IconLayout, startX + 4, textY, textColor);
-                            canvas.DrawLayout(msg.TimeLayout, startX + IconWidth + 8, textY, EditorTheme.Ink200);
-                            canvas.DrawLayout(msg.MessageLayout, startX + IconWidth + TimeWidth + 12, textY, textColor);
+                            canvas.DrawLayout(msg.IconLayout, paddedX + padStack, iconY, textColor);
+                            padStack += IconWidth + 10;
+
+                            if (_showTime)
+                            {
+                                canvas.DrawLayout(msg.TimeLayout, paddedX + padStack, iconY, EditorTheme.Ink200);
+                                padStack += TimeWidth + 4;
+                            }
+
+                            if (_multiLine)
+                            {
+                                float stackSize = size * 0.8f;
+                                float stackY = rowY + totalRowSize * (_multiLine ? 0.75f : 0.5f) - stackSize * 0.5f - 2;
+                                TextLayout stackTraceLayout = canvas.CreateLayout(msg.StackTrace.StackFrames[0].ToString(), new Prowl.Scribe.TextLayoutSettings { Font = font, PixelSize = stackSize });
+                                canvas.DrawLayout(stackTraceLayout, paddedX + padStack+1, stackY, EditorGUI.LerpRGB(textColor,Color.Black,0.25f));
+                            }
+
+                            canvas.DrawLayout(msg.MessageLayout, paddedX + padStack, textY, textColor);
 
                             // Count badge
-                            if (msg.Count > 1)
+                            if (_collapse && msg.Count > 1)
                             {
-                                msg.CountLayout ??= canvas.CreateLayout(msg.Count.ToString(), new Prowl.Scribe.TextLayoutSettings { Font = font, PixelSize = size });
-                                float badgeW = msg.CountLayout.Size.X / 2f + 8; // Size is in scaled pixels
-                                float badgeX = startX + (float)r.Size.X - badgeW - 6;
-                                float badgeY = rowY + (RowHeight - 14) * 0.5f;
+                                var textSize = size / 1.2f;
+                                msg.CountLayout ??= canvas.CreateLayout(msg.Count.ToString(), new Prowl.Scribe.TextLayoutSettings { Font = font, PixelSize = textSize });
+                                float badgeW = msg.CountLayout.Size.X + 8; // Size is in scaled pixels
+                                float badgeH = RowHeight - 6;
+                                float badgeX = startX + (float)r.Size.X - badgeW - 4;
+                                float badgeY = rowY + (_multiLine ? MultiLineRowHeight*0.25f : 0) + 3;
 
-                                canvas.RoundedRectFilled(badgeX, badgeY, badgeW, 14, 7, Color.FromArgb(120, 80, 80, 85));
-                                canvas.DrawLayout(msg.CountLayout, badgeX + 4, badgeY + 1, EditorTheme.Ink300);
+                                canvas.RoundedRectFilled(badgeX, badgeY, badgeW, badgeH, badgeH, Color.FromArgb(120, 80, 80, 85));
+                                canvas.DrawLayout(msg.CountLayout, badgeX + 4, badgeY + (badgeH - textSize) / 2f, EditorTheme.Ink400);
                             }
 
                             // Write back the cached layouts (struct copy)
@@ -275,7 +353,41 @@ public class ConsolePanel : DockPanel
             if (!string.IsNullOrEmpty(_searchText) &&
                 !msg.Message.Contains(_searchText, StringComparison.OrdinalIgnoreCase))
                 continue;
-            _filteredIndices.Add(i);
+            if (_collapse || msg.Count == 1)
+            {
+                _filteredIndices.Add(i);
+            }
+            else if (msg.Count > 1)
+            {
+                for (int t = 0; t < msg.Count; t++)
+                {
+                    _filteredIndices.Add(i);
+                }
+            }
+        }
+    }
+
+    private static void GetToggleStyle(LogSeverity severity, out Color textColor, out Color bgColor)
+    {
+        switch (severity)
+        {
+            case LogSeverity.Warning:
+                textColor = Color.FromArgb(255, 230, 200, 80);
+                bgColor = Color.FromArgb(20, 230, 200, 80);//visualIndex % 2 == 0 ? Color.FromArgb(10, 230, 200, 80) : Color.Transparent;
+                break;
+            case LogSeverity.Error:
+            case LogSeverity.Exception:
+                textColor = Color.FromArgb(255, 230, 80, 80);
+                bgColor = Color.FromArgb(20, 230, 80, 80);//visualIndex % 2 == 0 ? Color.FromArgb(10, 230, 80, 80) : Color.Transparent;
+                break;
+            case LogSeverity.Success:
+                textColor = Color.FromArgb(255, 80, 200, 80);
+                bgColor = Color.Transparent;
+                break;
+            default:
+                textColor = EditorTheme.Ink400;
+                bgColor = Color.FromArgb(10, 255, 255, 255);
+                break;
         }
     }
 
@@ -286,23 +398,23 @@ public class ConsolePanel : DockPanel
             case LogSeverity.Warning:
                 icon = EditorIcons.TriangleExclamation;
                 textColor = Color.FromArgb(255, 230, 200, 80);
-                bgColor = visualIndex % 2 == 0 ? Color.FromArgb(10, 230, 200, 80) : Color.Transparent;
+                bgColor = Color.FromArgb(20, 230, 200, 80);//visualIndex % 2 == 0 ? Color.FromArgb(10, 230, 200, 80) : Color.Transparent;
                 break;
             case LogSeverity.Error:
             case LogSeverity.Exception:
                 icon = EditorIcons.CircleExclamation;
                 textColor = Color.FromArgb(255, 230, 80, 80);
-                bgColor = visualIndex % 2 == 0 ? Color.FromArgb(10, 230, 80, 80) : Color.Transparent;
+                bgColor = Color.FromArgb(20, 230, 80, 80);//visualIndex % 2 == 0 ? Color.FromArgb(10, 230, 80, 80) : Color.Transparent;
                 break;
             case LogSeverity.Success:
                 icon = EditorIcons.CircleCheck;
                 textColor = Color.FromArgb(255, 80, 200, 80);
-                bgColor = Color.Transparent;
+                bgColor = Color.FromArgb(25, 80, 200, 80);
                 break;
             default:
                 icon = EditorIcons.CircleInfo;
-                textColor = EditorTheme.Ink500;
-                bgColor = visualIndex % 2 == 0 ? Color.FromArgb(8, 255, 255, 255) : Color.Transparent;
+                textColor = EditorTheme.Ink400;
+                bgColor = visualIndex % 2 == 0 ? Color.FromArgb(10, 255, 255, 255) : Color.Transparent;
                 break;
         }
     }

--- a/Prowl.Editor/Panels/ConsolePanel.cs
+++ b/Prowl.Editor/Panels/ConsolePanel.cs
@@ -68,6 +68,7 @@ public class ConsolePanel : DockPanel
         public Prowl.Scribe.TextLayout? TimeLayout;
         public Prowl.Scribe.TextLayout? MessageLayout;
         public Prowl.Scribe.TextLayout? CountLayout;
+        public Prowl.Scribe.TextLayout? StackTraceLayout;
     }
 
     public ConsolePanel()
@@ -298,6 +299,7 @@ public class ConsolePanel : DockPanel
                             msg.IconLayout ??= canvas.CreateLayout(icon, new Prowl.Scribe.TextLayoutSettings { Font = font, PixelSize = size });
                             msg.TimeLayout ??= canvas.CreateLayout(msg.TimeString, new Prowl.Scribe.TextLayoutSettings { Font = font, PixelSize = size });
                             msg.MessageLayout ??= canvas.CreateLayout(msg.Message, new Prowl.Scribe.TextLayoutSettings { Font = font, PixelSize = size });
+                            
 
 
                             float padStack = 4;
@@ -315,8 +317,8 @@ public class ConsolePanel : DockPanel
                             {
                                 float stackSize = size * 0.8f;
                                 float stackY = rowY + totalRowSize * (_multiLine ? 0.75f : 0.5f) - stackSize * 0.5f - 2;
-                                TextLayout stackTraceLayout = canvas.CreateLayout(msg.StackTrace.StackFrames[0].ToString(), new Prowl.Scribe.TextLayoutSettings { Font = font, PixelSize = stackSize });
-                                canvas.DrawLayout(stackTraceLayout, paddedX + padStack+1, stackY, EditorGUI.LerpRGB(textColor,Color.Black,0.25f));
+                                msg.StackTraceLayout ??= canvas.CreateLayout(msg.StackTrace.StackFrames[0].ToString(), new Prowl.Scribe.TextLayoutSettings { Font = font, PixelSize = stackSize });
+                                canvas.DrawLayout(msg.StackTraceLayout, paddedX + padStack+1, stackY, EditorGUI.LerpRGB(textColor,Color.Black,0.25f));
                             }
 
                             canvas.DrawLayout(msg.MessageLayout, paddedX + padStack, textY, textColor);

--- a/Prowl.Editor/Widgets/ContextMenuBuilder.cs
+++ b/Prowl.Editor/Widgets/ContextMenuBuilder.cs
@@ -4,6 +4,9 @@ using System.Collections.Generic;
 using Prowl.PaperUI;
 using Prowl.PaperUI.LayoutEngine;
 using Prowl.Runtime;
+using Prowl.Vector;
+
+using static System.Net.Mime.MediaTypeNames;
 
 using Color = System.Drawing.Color;
 
@@ -11,14 +14,22 @@ namespace Prowl.Editor.Widgets;
 
 public class ContextMenuBuilder
 {
-    private readonly List<ContextMenuItem> _items = new();
+    private readonly List<IContextMenuItem> _items = new();
     private Action? _onClose;
 
     internal void SetCloseAction(Action onClose) => _onClose = onClose;
 
-    public ContextMenuBuilder Item(string label, Action onClick, bool enabled = true, string icon = "")
+
+    public ContextMenuBuilder Toggle(string label, Action onClick, Func<bool> toggleValue, bool enabled = true, bool shouldCloseOnClick = false)
     {
-        _items.Add(new ContextMenuItem { Label = label, OnClick = onClick, IsEnabled = enabled, Icon = icon });
+        _items.Add(new ContextMenuToggle { Label = label, OnClick = onClick, ToggleValue = toggleValue, IsEnabled = enabled, ShouldCloseOnClick = shouldCloseOnClick});
+        return this;
+    }
+
+
+    public ContextMenuBuilder Item(string label, Action onClick, bool enabled = true, string icon = "", bool shouldCloseOnClick = true)
+    {
+        _items.Add(new ContextMenuItem { Label = label, OnClick = onClick, IsEnabled = enabled, Icon = icon, ShouldCloseOnClick = shouldCloseOnClick });
         return this;
     }
 
@@ -33,11 +44,11 @@ public class ContextMenuBuilder
         var sub = new ContextMenuBuilder();
         sub._onClose = _onClose;
         build(sub);
-        _items.Add(new ContextMenuItem { Label = label, SubMenu = sub, IsEnabled = true, Icon = icon });
+        _items.Add(new ContextMenuItem { Label = label, SubMenu = sub, IsEnabled = true, Icon = icon, ShouldCloseOnClick = false});
         return this;
     }
 
-    public void Render(Paper paper, string id, float x, float y, bool isSubmenu = false)
+    public void Render(Paper paper, string id, float x, float y, bool isSubmenu = false, Color? backgroundColor  = null)
     {
         var font = EditorTheme.DefaultFont;
         if (font == null) return;
@@ -47,7 +58,7 @@ public class ContextMenuBuilder
             .Position(x, y)
             .Width(200)
             .Height(UnitValue.Auto)
-            .BackgroundColor(EditorTheme.Purple200)
+            .BackgroundColor(backgroundColor ?? EditorTheme.Purple200)
             .BorderColor(EditorTheme.Ink200).BorderWidth(1.25f)
             .Rounded(4)
             .Layer(Layer.Topmost)
@@ -65,17 +76,51 @@ public class ContextMenuBuilder
                 {
                     var item = _items[i];
 
-                    if (item.IsSeparator)
-                    {
-                        paper.Box($"{id}_sep_{i}")
-                            .Height(1.25f).Margin(10, 5)
-                            .BackgroundColor(EditorTheme.Ink200);
-                        continue;
-                    }
-
                     var textColor = item.IsEnabled ? EditorTheme.Ink500 : EditorTheme.Ink300;
 
-                    using (paper.Row($"{id}_i_{i}")
+
+                    item.Draw(paper, id, i, font, textColor, _onClose);
+                    
+                }
+            }
+        }
+    }
+
+    private interface IContextMenuItem
+    {
+        public bool ShouldCloseOnClick { get; set; }
+        public bool IsEnabled { get; set; }
+        void Draw(Paper paper, string id, int index, Scribe.FontFile font, Color textColor, Action onClose = null);
+    }
+
+    private struct ContextMenuItem : IContextMenuItem
+    {
+        public string Icon;
+        public string Label;
+        public Action? OnClick;
+        public bool IsSeparator;
+
+        // Toggle support
+        public bool IsToggle;
+        public Func<bool>? ToggleValue;
+
+        public bool ShouldCloseOnClick { get; set; }
+        public bool IsEnabled { get; set; }
+        public ContextMenuBuilder? SubMenu;
+
+        public void Draw(Paper paper, string id, int index, Scribe.FontFile font, Color textColor, Action onClose = null)
+        {
+            ContextMenuItem item = this;
+
+            if (item.IsSeparator)
+            {
+                paper.Box($"{id}_sep_{index}")
+                    .Height(1.25f).Margin(10, 5)
+                    .BackgroundColor(EditorTheme.Ink200);
+                return;
+            }
+
+            using (paper.Row($"{id}_i_{index}")
                         .Height(EditorTheme.RowHeight)
                         .Hovered.BackgroundColor(item.IsEnabled ? EditorTheme.Purple400 : Color.Transparent).End()
                         .Rounded(3)
@@ -84,57 +129,100 @@ public class ContextMenuBuilder
                             if (captured.IsEnabled)
                             {
                                 captured.OnClick?.Invoke();
-                                _onClose?.Invoke();
+                                if (item.ShouldCloseOnClick)
+                                    onClose?.Invoke();
                             }
                         })
                         .Enter())
-                    {
-                        if (string.IsNullOrWhiteSpace(item.Icon))
-                        {
-                            paper.Box($"{id}_l_{i}")
-                                .Width(UnitValue.Stretch())
-                                .Margin(10, 0, 0, 0)
-                                .Height(EditorTheme.RowHeight)
-                                .Text(item.Label, font).TextColor(textColor).FontSize(EditorTheme.FontSize).Alignment(TextAlignment.MiddleLeft);
-                        }
-                        else
-                        {
-                            paper.Box($"{id}_i_{i}")
-                                .Margin(10, 0, 0, 0)
-                                .Size(EditorTheme.RowHeight)
-                                .Text(item.Icon, font).TextColor(textColor).FontSize(EditorTheme.FontSize).Alignment(TextAlignment.MiddleLeft);
+            {
+                if (string.IsNullOrWhiteSpace(item.Icon))
+                {
+                    paper.Box($"{id}_l_{index}")
+                        .Width(UnitValue.Stretch())
+                        .Margin(10, 0, 0, 0)
+                        .Height(EditorTheme.RowHeight)
+                        .Text(item.Label, font).TextColor(textColor).FontSize(EditorTheme.FontSize).Alignment(TextAlignment.MiddleLeft);
+                }
+                else
+                {
+                    paper.Box($"{id}_i_{index}")
+                        .Margin(10, 0, 0, 0)
+                        .Size(EditorTheme.RowHeight)
+                        .Text(item.Icon, font).TextColor(textColor).FontSize(EditorTheme.FontSize).Alignment(TextAlignment.MiddleLeft);
 
-                            paper.Box($"{id}_l_{i}")
-                                .Width(UnitValue.Stretch())
-                                .Margin(5, 0, 0, 0)
-                                .Height(EditorTheme.RowHeight)
-                                .Text(item.Label, font).TextColor(textColor).FontSize(EditorTheme.FontSize).Alignment(TextAlignment.MiddleLeft);
-                        }
+                    paper.Box($"{id}_l_{index}")
+                        .Width(UnitValue.Stretch())
+                        .Margin(5, 0, 0, 0)
+                        .Height(EditorTheme.RowHeight)
+                        .Text(item.Label, font).TextColor(textColor).FontSize(EditorTheme.FontSize).Alignment(TextAlignment.MiddleLeft);
+                }
 
 
-                        if (item.SubMenu != null)
-                        {
-                            paper.Box($"{id}_a_{i}")
-                                .Size(EditorTheme.RowHeight)
-                                .Text(EditorIcons.ChevronRight, font).TextColor(EditorTheme.Ink400).FontSize(10f).Alignment(TextAlignment.MiddleLeft);
+                if (item.SubMenu != null)
+                {
+                    paper.Box($"{id}_a_{index}")
+                        .Size(EditorTheme.RowHeight)
+                        .Text(EditorIcons.ChevronRight, font).TextColor(EditorTheme.Ink400).FontSize(10f).Alignment(TextAlignment.MiddleLeft);
 
-                            if (paper.IsParentHovered)
-                                item.SubMenu.Render(paper, $"{id}_s_{i}", 190, 0, isSubmenu: true);
-                        }
-                    }
+                    if (paper.IsParentHovered)
+                        item.SubMenu.Render(paper, $"{id}_s_{index}", 190, 0, isSubmenu: true);
                 }
             }
         }
     }
 
-    private struct ContextMenuItem
+    private struct ContextMenuToggle : IContextMenuItem
     {
-        public string Icon;
         public string Label;
         public Action? OnClick;
-        public bool IsSeparator;
-        public bool IsEnabled;
-        public ContextMenuBuilder? SubMenu;
+
+        // Toggle support
+        public bool IsToggle;
+        public Func<bool>? ToggleValue;
+
+        public bool ShouldCloseOnClick { get; set; }
+        public bool IsEnabled { get; set; }
+
+        public void Draw(Paper paper, string id, int index, Scribe.FontFile font, Color textColor, Action onClose = null)
+        {
+            ContextMenuToggle item = this;
+
+            using (paper.Row($"{id}_i_{index}")
+                        .Height(EditorTheme.RowHeight)
+                        .Hovered.BackgroundColor(item.IsEnabled ? EditorTheme.Purple400 : Color.Transparent).End()
+                        .Rounded(3)
+                        .OnClick(item, (captured, e) =>
+                        {
+                            if (captured.IsEnabled)
+                            {
+                                captured.OnClick?.Invoke();
+                                if (item.ShouldCloseOnClick)
+                                    onClose?.Invoke();
+                            }
+                        })
+                        .Enter())
+            {
+
+                /*paper.Box($"{id}_i_{index}")
+                    .Margin(10, 0, 0, 0)
+                    .Size(EditorTheme.RowHeight)
+                    .Text(item.Icon, font).TextColor(textColor).FontSize(EditorTheme.FontSize).Alignment(TextAlignment.MiddleLeft);*/
+
+                EditorGUI.Toggle(paper, $"{id}_t_{index}", "", item.ToggleValue?.Invoke() ?? false).OnValueChanged(newValue =>
+                {
+                    item.OnClick?.Invoke();
+                    onClose?.Invoke();
+                });
+
+
+                paper.Box($"{id}_l_{index}")
+                        .Width(UnitValue.Stretch())
+                        .Margin(5, 0, 0, 0)
+                        .Height(EditorTheme.RowHeight)
+                        .Text(item.Label, font).TextColor(textColor).FontSize(EditorTheme.FontSize).Alignment(TextAlignment.MiddleLeft);
+
+            }
+        }
     }
 }
 
@@ -149,6 +237,126 @@ public static class ContextMenuHelper
 
     // Track the currently open menu so we can close it
     private static Action? _closeCurrentMenu;
+
+    public static void OpenContextMenu(Paper paper, string id, ElementHandle? parent = null)
+    {
+        var parentEl = parent ?? paper.CurrentParent;
+
+        var relativePosition = new Float2(
+                //Input.MousePosition.X - parentEl.Owner.ScreenRect.Min.X,
+                //Input.MousePosition.Y - parentEl.Owner.ScreenRect.Min.Y
+                parentEl.Data.RelativeX + (Input.MousePosition.X - parentEl.Data.X),
+                parentEl.Data.RelativeY + (Input.MousePosition.Y - parentEl.Data.Y)
+            );
+
+        long frame = Time.FrameCount;
+        if (_openedOnFrame == frame) return; // Another menu already opened this frame
+        _openedOnFrame = frame;
+
+        // Close any previously open menu
+        _closeCurrentMenu?.Invoke();
+
+        paper.SetElementStorage(parentEl, $"{id}_open", true);
+        paper.SetElementStorage(parentEl, $"{id}_x", (float)relativePosition.X);
+        paper.SetElementStorage(parentEl, $"{id}_y", (float)relativePosition.Y);
+    }
+
+    public static bool ContextMenu(Paper paper, string id, Action<ContextMenuBuilder> build, ElementHandle? parent = null)
+    {
+        var parentEl = parent ?? paper.CurrentParent;
+        bool isOpen = paper.GetElementStorage(parentEl, $"{id}_open", false);
+        float menuX = paper.GetElementStorage(parentEl, $"{id}_x", 0f);
+        float menuY = paper.GetElementStorage(parentEl, $"{id}_y", 0f);
+
+        if (isOpen)
+        {
+            Action close = () => paper.SetElementStorage(parentEl, $"{id}_open", false);
+            _closeCurrentMenu = close;
+
+            var builder = new ContextMenuBuilder();
+            builder.SetCloseAction(close);
+            build(builder);
+
+            using (paper.Box($"{id}_anchor")
+                .PositionType(PositionType.SelfDirected)
+                .Position(menuX, menuY)
+                .Width(UnitValue.Auto).Height(UnitValue.Auto)
+                .StopEventPropagation()
+                .Enter())
+            {
+
+                // Fullscreen backdrop — click to close
+                paper.Box($"{id}_backdrop")
+                    .PositionType(PositionType.SelfDirected)
+                    .Position(-9999, -9999)
+                    .Size(99999, 99999)
+                    .Layer(Layer.Topmost)
+                    .StopEventPropagation()
+                    .OnClick(0, (_, _) => close())
+                    .OnRightClick(0, (_, _) => close());
+
+                builder.Render(paper, $"{id}_ctx", 0, 0);
+            }
+        }
+
+        return isOpen;
+    }
+
+    public static bool ClickMenu(Paper paper, string id, Action<ContextMenuBuilder> build, ElementHandle? parent = null)
+    {
+        var parentEl = parent ?? paper.CurrentParent;
+        bool isOpen = paper.GetElementStorage(parentEl, $"{id}_open", false);
+        float menuX = paper.GetElementStorage(parentEl, $"{id}_x", 0f);
+        float menuY = paper.GetElementStorage(parentEl, $"{id}_y", 0f);
+
+        // Right-click opens at cursor position — only if no other menu opened this frame
+        parentEl.Data.OnClick += e =>
+        {
+            long frame = Time.FrameCount;
+            if (_openedOnFrame == frame) return; // Another menu already opened this frame
+            _openedOnFrame = frame;
+
+            // Close any previously open menu
+            _closeCurrentMenu?.Invoke();
+
+            paper.SetElementStorage(parentEl, $"{id}_open", true);
+            paper.SetElementStorage(parentEl, $"{id}_x", (float)e.RelativePosition.X);
+            paper.SetElementStorage(parentEl, $"{id}_y", (float)e.RelativePosition.Y);
+        };
+
+        if (isOpen)
+        {
+            Action close = () => paper.SetElementStorage(parentEl, $"{id}_open", false);
+            _closeCurrentMenu = close;
+
+            var builder = new ContextMenuBuilder();
+            builder.SetCloseAction(close);
+            build(builder);
+
+            // Fullscreen backdrop — click to close
+            paper.Box($"{id}_backdrop")
+                .PositionType(PositionType.SelfDirected)
+                .Position(-9999, -9999)
+                .Size(99999, 99999)
+                .BackgroundColor(Color.FromArgb(85, 0, 0, 0))
+                .Layer(Layer.Topmost)
+                .StopEventPropagation()
+                .OnClick(0, (_, _) => close())
+                .OnRightClick(0, (_, _) => close());
+
+            using (paper.Box($"{id}_anchor")
+                .PositionType(PositionType.SelfDirected)
+                .Position(menuX, menuY)
+                .Width(UnitValue.Auto).Height(UnitValue.Auto)
+                .StopEventPropagation()
+                .Enter())
+            {
+                builder.Render(paper, $"{id}_ctx", 0, 0, backgroundColor: EditorTheme.Neutral200);
+            }
+        }
+
+        return isOpen;
+    }
 
     public static bool RightClickMenu(Paper paper, string id, Action<ContextMenuBuilder> build)
     {

--- a/Prowl.Editor/Widgets/EditorGUI.cs
+++ b/Prowl.Editor/Widgets/EditorGUI.cs
@@ -180,6 +180,28 @@ public static class EditorGUI
         return new WidgetResult<bool>(cb => userCallback = cb);
     }
 
+    public static WidgetResult<bool> ButtonSquareWithHandle(Paper paper, string id, string icon, out ElementHandle buttonEl)
+    {
+        Action<bool>? userCallback = null;
+
+        buttonEl = paper.Box(id)
+            .Alignment(PaperUI.TextAlignment.MiddleCenter)
+            .Text(icon, Font)
+            .TextColor(EditorTheme.Ink500)
+            .FontSize(FontSz)
+            .Height(EditorTheme.RowHeight)
+            .Width(EditorTheme.RowHeight)
+            .BackgroundColor(EditorTheme.Ink100)
+            .Hovered.BackgroundColor(EditorTheme.Ink200).End()
+            .Rounded(3)
+            .BorderColor(EditorTheme.Ink100)
+            .BorderWidth(1)
+            .OnClick(e => userCallback?.Invoke(true))
+            ._handle;
+
+        return new WidgetResult<bool>(cb => userCallback = cb);
+    }
+
     public static WidgetResult<bool> ButtonSquareGhost(Paper paper, string id, string icon)
     {
         Action<bool>? userCallback = null;
@@ -213,6 +235,7 @@ public static class EditorGUI
         using (paper.Row(id)
             .Height(EditorTheme.RowHeight)
             .Width(UnitValue.Auto)
+            .Alignment(PaperUI.TextAlignment.MiddleLeft)
             .RowBetween(6)
             .OnClick(e => userCallback?.Invoke(!value))
             .Enter())
@@ -616,7 +639,7 @@ public static class EditorGUI
                     float rw = (float)r.Size.X;
                     float rh = (float)r.Size.Y;
 
-                    float trackH = 4f;
+                    float trackH = 12f;
                     float trackY = ry + rh * 0.5f - trackH * 0.5f;
                     float trackR = trackH * 0.5f;
                     float thumbCx = rx + rw * t;
@@ -624,7 +647,7 @@ public static class EditorGUI
                     float thumbR = rh * 0.36f;
 
                     // ── Track background ──────────────────────────────────
-                    canvas.RoundedRectFilled(rx, trackY, rw, trackH, trackR, trackR, trackR, trackR,
+                    canvas.RoundedRectFilled(rx, trackY, rw, trackH, 0, 0, 0, 0,
                         EditorTheme.Ink100);
 
                     // ── Track fill ────────────────────────────────────────
@@ -635,10 +658,10 @@ public static class EditorGUI
                     }
 
                     // ── Thumb body ────────────────────────────────────────
-                    canvas.SetFillColor(EditorTheme.Ink500);
+                    /*canvas.SetFillColor(EditorTheme.Ink500);
                     canvas.BeginPath();
                     canvas.Circle(thumbCx, thumbCy, thumbR, 24);
-                    canvas.Fill();
+                    canvas.Fill();*/
                 }));
 
             if (showField)
@@ -854,15 +877,24 @@ public static class EditorGUI
     //  ToggleButton
     // ================================================================
 
-    public static WidgetResult<bool> ToggleButton(Paper paper, string id, string label, bool value)
+    public static WidgetResult<bool> ToggleButton(Paper paper, string id, string label, bool value, int? width = null, bool fitWidth = false, Color? textColorOverride = null, Color ? bgColorOverride = null)
     {
         Action<bool>? userCallback = null;
-        
+
+        UnitValue widthValue = UnitValue.Auto;
+
+        if (fitWidth)
+        {
+            Prowl.Vector.Float2 labelLayout = paper.MeasureText(label, new Prowl.Scribe.TextLayoutSettings { Font = Font, PixelSize = FontSz });
+            widthValue = labelLayout.X + (EditorTheme.RowHeight / 4) * 2;
+        }
+
         using (paper.Box(id)
+            .Width(width ?? widthValue)
             .Height(EditorTheme.RowHeight)
             .ChildLeft(EditorTheme.RowHeight/4).ChildRight(EditorTheme.RowHeight/4)
-            .BackgroundColor(value ? EditorTheme.Purple400 : EditorTheme.Ink100)
-            .Hovered.BackgroundColor(value ? EditorTheme.Purple300 : EditorTheme.Ink200).End()
+            .BackgroundColor(value ? (bgColorOverride ?? EditorTheme.Purple400) : EditorTheme.Ink100)
+            .Hovered.BackgroundColor(value ? (bgColorOverride.HasValue ? LerpRGB(bgColorOverride.Value, Color.Black,0.25f) : EditorTheme.Purple300) : EditorTheme.Ink200).End()
             .Rounded(3)
             .BorderColor(EditorTheme.Ink200).BorderWidth(1)
             .OnClick(e => userCallback?.Invoke(!value)).Enter())
@@ -871,7 +903,7 @@ public static class EditorGUI
                 paper.Box($"{id}_label")
                     .Alignment(PaperUI.TextAlignment.MiddleLeft)
                     .Text(label, Font)
-                    .TextColor(EditorTheme.Ink500)
+                    .TextColor(textColorOverride ?? EditorTheme.Ink500)
                     .FontSize(FontSz);
         }
 
@@ -888,13 +920,15 @@ public static class EditorGUI
 
         using (paper.Row(id)
             .Height(EditorTheme.RowHeight)
-        
+
+
             .Rounded(3)
             .BorderWidth(1)
-            
+            .Alignment(PaperUI.TextAlignment.MiddleLeft)
+
             .BackgroundColor(EditorTheme.Neutral200)
             .BorderColor(EditorTheme.Neutral100)
-            .Margin(UnitValue.Auto, EditorTheme.Spacing)
+            .Margin(UnitValue.Auto, UnitValue.Auto, UnitValue.Auto, EditorTheme.Spacing)
             .Focused.BorderColor(EditorTheme.Purple400).End()
             
             .ChildLeft(6).ChildRight(4)
@@ -1119,7 +1153,7 @@ public static class EditorGUI
                     (int)(value.G * 255),
                     (int)(value.B * 255)))
                 .Rounded(4)
-                .BorderColor(EditorTheme.Ink200).BorderWidth(2)
+                .BorderColor(EditorTheme.Ink200).BorderWidth(1)
                 .Hovered.BorderColor(EditorTheme.Purple400).End()
                 .Enter())
             {

--- a/Prowl.Editor/Widgets/ScrollView.cs
+++ b/Prowl.Editor/Widgets/ScrollView.cs
@@ -31,7 +31,7 @@ public static class ScrollView
 
     public static IDisposable Begin(Paper paper, string id, float width, float height,
         float paddingLeft = 0, float paddingRight = 0, float paddingTop = 0, float paddingBottom = 0,
-        float colSpacing = 0)
+        float colSpacing = 0, bool forceScrollbar = false)
     {
         // We need the outer handle for storage, but can't capture it before Enter().
         // Declare it here and set it after Enter().
@@ -63,7 +63,7 @@ public static class ScrollView
         // Read scroll position (persisted from last frame)
         float scrollY = paper.GetElementStorage(outerHandle, "scrollY", 0f);
         float contentHeight = paper.GetElementStorage(outerHandle, "contentH", height);
-        bool needsScrollbar = contentHeight > height;
+        bool needsScrollbar = contentHeight > height || forceScrollbar;
         float contentW = needsScrollbar ? width - ScrollBarWidth : width;
 
         // Content column


### PR DESCRIPTION
- Polished the Console Panel to give it a more intuitive look
<img width="630" height="318" alt="image" src="https://github.com/user-attachments/assets/94724933-4839-413b-8424-8b296071ad3a" />
- Improved the Console Functionalities to fully support multiline, collapsing, time toggling
<img width="867" height="512" alt="image" src="https://github.com/user-attachments/assets/e6f82219-51c1-4664-87e3-f20c6c4386d7" />
<img width="851" height="287" alt="image" src="https://github.com/user-attachments/assets/c0702209-7a9e-463b-9f82-57f6a7036c60" />
- Added a couple helpers to ContextMenuHelper and EditorGUI
- Minor rework of ContextMenuBuilder
   - Now each item can be handled separately via its own struct, all use the IContextMenuItem interface