### PR TITLE
Fixed Paper version build error

### DIFF
--- a/Prowl.Editor/Build/DesktopBuildPipeline.cs
+++ b/Prowl.Editor/Build/DesktopBuildPipeline.cs
@@ -347,9 +347,10 @@ public class DesktopBuildPipeline : BuildPipeline
         sb.AppendLine("    <PackageReference Include=\"Silk.NET\" Version=\"2.22.0\" />");
         sb.AppendLine("    <PackageReference Include=\"Silk.NET.OpenAL.Soft.Native\" Version=\"1.23.1\" />");
         sb.AppendLine("    <PackageReference Include=\"Jitter2\" Version=\"2.7.3\" />");
-        sb.AppendLine("    <PackageReference Include=\"Magick.NET-Q16-AnyCPU\" Version=\"14.9.1\" />");
+        sb.AppendLine("    <PackageReference Include=\"Magick.NET-Q16-AnyCPU\" Version=\"14.11.1\" />");
         sb.AppendLine("    <PackageReference Include=\"Prowl.Echo\" Version=\"2.1.2\" />");
         sb.AppendLine("    <PackageReference Include=\"Prowl.Paper\" Version=\"1.3.1\" />");
+        sb.AppendLine("    <PackageReference Include=\"Prowl.Paper\" Version=\"1.4.1\" />");
         sb.AppendLine("  </ItemGroup>");
 
         // User NuGet packages from ProjectSettings/Packages.json


### PR DESCRIPTION
Fixed the required versions for Paper and Magick.NET in the generated Csproj for builds.