### PR TITLE
Fixed DPI Scaling issue

### DIFF
--- a/Prowl.Editor/EditorApplication.cs
+++ b/Prowl.Editor/EditorApplication.cs
@@ -40,8 +40,15 @@ public class EditorApplication : Game
         Window.InitWindow(title, width, height, instance.WindowMaximized ? Silk.NET.Windowing.WindowState.Maximized : Silk.NET.Windowing.WindowState.Normal, false);
 
         Window.Position = new Silk.NET.Maths.Vector2D<int>(
-            instance.WindowX > -1 ? instance.WindowX : Window.Position.X,
-            instance.WindowY > -1 ? instance.WindowY : Window.Position.Y);
+            instance.WindowX > 0 ? instance.WindowX : Window.Position.X,
+            instance.WindowY > 0 ? instance.WindowY : Window.Position.Y);
+
+        PaperInstance?.SetReferenceResolution(width / Window.ContentScale * EditorTheme.UserScale, height / Window.ContentScale * EditorTheme.UserScale);
+    }
+
+    public override void Resize(int width, int height)
+    {
+        PaperInstance?.SetReferenceResolution(width / Window.ContentScale * EditorTheme.UserScale, height / Window.ContentScale * EditorTheme.UserScale);
     }
 
     public override void Initialize()
@@ -53,6 +60,8 @@ public class EditorApplication : Game
         // Set invariant culture for consistent number parsing/formatting in the editor (e.g. asset import settings)
         System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.InvariantCulture;
         InitializeFont();
+
+        Resize(Window.Size.X, Window.Size.Y);
 
         PaperInstance.TextMode = Prowl.Quill.TextRenderMode.Bitmap;
 

--- a/Prowl.Editor/EditorTheme.cs
+++ b/Prowl.Editor/EditorTheme.cs
@@ -12,6 +12,9 @@ public static class EditorTheme
     public static string DefaultFontName = "bahnschrift";
     public static string DefaultBoldFontName = "bahnschrift";
 
+    // DPI Scaling value
+    public static float UserScale { get; set; } = 1f;
+
     // Sizing — mutable so themes can override
     public static float MenuBarHeight = 26f;
     public static float StatusBarHeight = 22f;
@@ -19,7 +22,7 @@ public static class EditorTheme
     public static float Spacing = 2f;
     public static float Padding = 4f;
     public static float FontSize = 17f;
-    public static float LabelWidth = 120f;
+    public static float LabelWidth = 200f;
     public static float Roundness = 8f;
 
     public static float IndicatorSize = 28f;

--- a/Prowl.Editor/Panels/PreferencesPanel.cs
+++ b/Prowl.Editor/Panels/PreferencesPanel.cs
@@ -191,6 +191,12 @@ public class PreferencesPanel : DockPanel
 
 
         // ── Sizing ──
+        EditorGUI.Foldout(paper, "pref_scl_general", "General Sizing", () =>
+        {
+            SzSlider(paper, s, "User Scale", theme.UserScale, 0.5f, 2, v => theme.UserScale = v);
+        });
+
+        // ── Sizing ──
         EditorGUI.Foldout(paper, "pref_sz_general", "General Sizing", () =>
         {
             SzSlider(paper, s, "Font Size", theme.FontSize, 8, 32, v => theme.FontSize = v);

--- a/Prowl.Editor/Settings/EditorSettings.cs
+++ b/Prowl.Editor/Settings/EditorSettings.cs
@@ -92,6 +92,8 @@ public class EditorSettings
                 
         EditorApplication.Instance?.InitializeFont();
 
+        EditorTheme.UserScale = t.UserScale;
+
         // Sizing
         EditorTheme.MenuBarHeight = t.MenuBarHeight;
         EditorTheme.RowHeight = t.RowHeight;

--- a/Prowl.Editor/Settings/EditorThemeData.cs
+++ b/Prowl.Editor/Settings/EditorThemeData.cs
@@ -95,6 +95,8 @@ public class EditorThemeData
 
     public string DefaultBoldFontName { get; set; } = "bahnschrift";
 
+    public float UserScale { get; set; } = 1f;
+
     // Sizing
     public float MenuBarHeight { get; set; } = 26f;
     public float RowHeight { get; set; } = 22f;

--- a/Prowl.Editor/Widgets/EditorGUI.cs
+++ b/Prowl.Editor/Widgets/EditorGUI.cs
@@ -700,6 +700,7 @@ public static class EditorGUI
             .Height(EditorTheme.RowHeight)
             .Alignment(PaperUI.TextAlignment.MiddleLeft)
             .ChildLeft(4)
+            .Margin(UnitValue.Auto, EditorTheme.Spacing)
             .BackgroundColor(EditorTheme.Neutral300)
             .Hovered.BackgroundColor(EditorTheme.Ink200).End()
             .Rounded(2);

--- a/Prowl.Runtime/Game.cs
+++ b/Prowl.Runtime/Game.cs
@@ -64,7 +64,7 @@ public abstract class Game
             _paperRenderer = new PaperRenderer();
             _paperRenderer.Initialize(fbSize.X, fbSize.Y);
             _paper = new Paper(_paperRenderer, winSize.X, winSize.Y, new Prowl.Quill.FontAtlasSettings());
-            _paper.SetReferenceResolution(1280, 720);
+            _paper.SetReferenceResolution(width, height);
             _paper.SetClipboardHandler(new RuntimeClipboardHandler());
 
             BuiltInAssets.Initialize();

--- a/Prowl.Runtime/Window.cs
+++ b/Prowl.Runtime/Window.cs
@@ -28,6 +28,54 @@ public static class Window
     public static event Action<WindowState>? StateChanged;
     public static event Action<string[]>? FileDrop;
 
+    private static nint s_contentScaleProc;
+    private static bool s_contentScaleResolved;
+
+    /// <summary>
+    /// System content scale factor (1.0 = 100%, 1.25 = 125%, 1.5 = 150%, etc.).
+    /// Derived from framebuffer-to-window size ratio reported by GLFW.
+    /// </summary>
+    public static float ContentScale
+    {
+        get
+        {
+            if (InternalWindow == null) return 1f;
+
+            nint? nativeGlfw = InternalWindow.Native?.Glfw;
+            if (nativeGlfw.HasValue && TryGetContentScale(nativeGlfw.Value, out float scale))
+                return scale;
+
+            // If the scale through the native method is unavailable, Framebuffer pixels ÷ logical pixels = OS content scale
+            var fb = InternalWindow.FramebufferSize;
+            var win = InternalWindow.Size;
+            return win.X > 0 ? (float)fb.X / win.X : 1f;
+        }
+    }
+
+    private static unsafe bool TryGetContentScale(nint glfwWindow, out float scale)
+    {
+        scale = 1f;
+
+        if (!s_contentScaleResolved)
+        {
+            s_contentScaleResolved = true;
+            try
+            {
+                // Resolve from the same native library Silk.NET already loaded
+                s_contentScaleProc = Silk.NET.GLFW.GlfwProvider.GLFW.Value.Context.GetProcAddress("glfwGetWindowContentScale");
+            }
+            catch { /* symbol not exported (GLFW < 3.3) */ }
+        }
+
+        if (s_contentScaleProc == 0)
+            return false;
+
+        float x, y;
+        ((delegate* unmanaged[Cdecl]<nint, float*, float*, void>)s_contentScaleProc)(glfwWindow, &x, &y);
+        scale = x;
+        return true;
+    }
+
     public static Vector2D<int> Position
     {
         get { return InternalWindow.Position; }


### PR DESCRIPTION
Fixes the DPI Scaling issue in the editor, especially when resizing the editor window. 
- To load the System DPI scale, it relies on the currently unexposed method "glfwGetWindowContentScale" from GLFW (which is loaded by Silk) and should work across platforms.
- A variable called "UserScale" is added in the EditorTheme as an additional multiplier for the user to tune the Scaling as they like.