### PR TITLE
Reworked RenameOverlay for better renaming support

### DIFF
--- a/Prowl.Editor/Widgets/RenameOverlay.cs
+++ b/Prowl.Editor/Widgets/RenameOverlay.cs
@@ -94,17 +94,21 @@ public static class RenameOverlay
             .TabIndex(0)
             .Enter())
         {
-            paper.Box($"{id}_tf")
+            var textField = paper.Box($"{id}_tf")
                 .Margin(4, UnitValue.Stretch())
                 .HookToParent()
                 .IsNotInteractable()
+                .Alignment(TextAlignment.MiddleLeft)
                 .Width(UnitValue.Stretch())
-                .Height(EditorTheme.RowHeight)
+                .Height(EditorTheme.FontSize)
                 .FontSize(EditorTheme.FontSize - 1)
                 .TextField(_text, font,
                     onChange: v => _text = v,
                     textColor: EditorTheme.Ink500,
                     intID: _activeId?.GetHashCode() ?? 0);
+
+            if (!paper.IsElementFocused(textField._handle.Data.ID))
+                paper.SetFocus(textField._handle);
             // TODO: Waiting on a paper update to include the SelectAllOnFocus setting to Text Fields
         }
     }

--- a/Prowl.Editor/Widgets/RenameOverlay.cs
+++ b/Prowl.Editor/Widgets/RenameOverlay.cs
@@ -13,6 +13,12 @@ namespace Prowl.Editor.Widgets;
 /// </summary>
 public static class RenameOverlay
 {
+    public enum Position
+    {
+        Top,
+        Bottom
+    }
+
     private static bool _active;
     private static string _text = "";
     private static Action<string>? _onConfirm;
@@ -57,7 +63,7 @@ public static class RenameOverlay
     /// Draw the rename field at this location. Renders a fullscreen backdrop behind it
     /// and the text field on top, both on Layer.Topmost. Same pattern as ContextMenuHelper.
     /// </summary>
-    public static void Draw(Paper paper, string id)
+    public static void Draw(Paper paper, string id, Position position = Position.Top)
     {
         var font = EditorTheme.DefaultFont;
         if (font == null) return;
@@ -82,7 +88,7 @@ public static class RenameOverlay
         // Rename field — positioned at (0,0) relative to parent, on top of backdrop
         using (paper.Box($"{id}_field")
             .PositionType(PositionType.SelfDirected)
-            .Position(0, 0)
+            .Position(0, (position == Position.Top ? 0 : UnitValue.Stretch()))
             .Width(UnitValue.Stretch())
             .Height(EditorTheme.RowHeight)
             .Rounded(3)


### PR DESCRIPTION
Added autofocus upon Rename Overlay opening and positional override. Currently waiting for better (or open) cursor support to automatically select the entire text when starting the rename process (currently, everything on Paper's side to manage that is private- is it fine if I change that as well?)