### PR TITLE
IDebugDrawer gizmos for all colliders

### DIFF
--- a/Prowl.Runtime/Components/Physics/Colliders/Collider.cs
+++ b/Prowl.Runtime/Components/Physics/Colliders/Collider.cs
@@ -340,6 +340,13 @@ public abstract class Collider : MonoBehaviour
         }
     }
 
+    public override void DrawGizmos()
+    {
+        if (_attachedBody == null || _attachedBody.Handle.IsZero) return;
+
+        _attachedBody.DebugDraw(JitterGizmosDrawer.Instance);
+    }
+
     public override void OnValidate()
     {
         // If we're attached to a Rigidbody3D, refresh it

--- a/Prowl.Runtime/Components/Physics/Colliders/Collider.cs
+++ b/Prowl.Runtime/Components/Physics/Colliders/Collider.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See the LICENSE file in the project root for details.
 
 using System;
-using System.ComponentModel;
 
 using Jitter2.Collision.Shapes;
 using Jitter2.LinearMath;
@@ -338,13 +337,6 @@ public abstract class Collider : MonoBehaviour
                 AttachToStatic();
             }
         }
-    }
-
-    public override void DrawGizmos()
-    {
-        if (_attachedBody == null || _attachedBody.Handle.IsZero) return;
-
-        _attachedBody.DebugDraw(JitterGizmosDrawer.Instance);
     }
 
     public override void OnValidate()

--- a/Prowl.Runtime/Components/Physics/Rigidbody3D.cs
+++ b/Prowl.Runtime/Components/Physics/Rigidbody3D.cs
@@ -362,12 +362,13 @@ public sealed class Rigidbody3D : MonoBehaviour
         interpTimer = 0;
     }
 
-    public override void DrawGizmos()
-    {
-        if (_body == null || _body.Handle.IsZero) return;
+    
+    // public override void DrawGizmos()
+    // {
+    //     if (_body == null || _body.Handle.IsZero) return;
 
-        _body.DebugDraw(JitterGizmosDrawer.Instance);
-    }
+    //     _body.DebugDraw(JitterGizmosDrawer.Instance);
+    // }
 
     public override void OnEnable()
     {

--- a/Prowl.Runtime/Components/Physics/Rigidbody3D.cs
+++ b/Prowl.Runtime/Components/Physics/Rigidbody3D.cs
@@ -357,6 +357,13 @@ public sealed class Rigidbody3D : MonoBehaviour
         Transform.Rotation = new Quaternion(predictedOrientation.X, predictedOrientation.Y, predictedOrientation.Z, predictedOrientation.W);
     }
 
+    public override void DrawGizmos()
+    {
+        if (_body == null || _body.Handle.IsZero) return;
+
+        _body.DebugDraw(JitterGizmosDrawer.Instance);
+    }
+
     public override void FixedUpdate()
     {
         interpTimer = 0;

--- a/Prowl.Runtime/Components/Physics/Rigidbody3D.cs
+++ b/Prowl.Runtime/Components/Physics/Rigidbody3D.cs
@@ -362,14 +362,6 @@ public sealed class Rigidbody3D : MonoBehaviour
         interpTimer = 0;
     }
 
-    
-    // public override void DrawGizmos()
-    // {
-    //     if (_body == null || _body.Handle.IsZero) return;
-
-    //     _body.DebugDraw(JitterGizmosDrawer.Instance);
-    // }
-
     public override void OnEnable()
     {
         if (_body == null || _body.Handle.IsZero)

--- a/Prowl.Runtime/Physics/PhysicsWorld.cs
+++ b/Prowl.Runtime/Physics/PhysicsWorld.cs
@@ -181,6 +181,16 @@ public class PhysicsWorld
         World.Step(Time.FixedDeltaTime, UseMultithreading);
     }
 
+    public void DrawStaticRigidbodyGizmos()
+    {
+        foreach (var body in _staticRigidbodiesByLayer.Values)
+        {
+            if (body.Handle.IsZero) continue;
+
+            body.DebugDraw(JitterGizmosDrawer.Instance);
+        }
+    }
+
     /// <summary>
     /// Casts a ray against all colliders in this physics world.
     /// </summary>

--- a/Prowl.Runtime/Resources/Scene.cs
+++ b/Prowl.Runtime/Resources/Scene.cs
@@ -595,6 +595,9 @@ public class Scene : EngineObject, ISerializationCallbackReceiver
     /// </summary>
     public void DrawGizmos()
     {
+        // Draw physics gizmos
+        _physics.DrawStaticRigidbodyGizmos();
+
         List<GameObject> activeGOs = [.. ActiveObjects];
         ForeachComponent(activeGOs, (x) =>
         {


### PR DESCRIPTION
Adds debug drawer drawing for Colliders. This was a one line change since support for it was already added previously ~~but for some reason it causes 2 fps~~. Though... FPS drops to 45 fps from 300 fps in my test project.

`Prowl.Runtime/Components/Physics/Colliders/Collider.cs`:

```cs
public override void DrawGizmos()
{
    if (_attachedBody == null || _attachedBody.Handle.IsZero) return;

    _attachedBody.DebugDraw(JitterGizmosDrawer.Instance);
}
```

> [!NOTE]
> You do have to click play for the gizmos to start drawing.