### PR TITLE
Switched list iteration flow for GameObject rendering and updates

### DIFF
--- a/Prowl.Runtime.Generators/EquatableArray.cs
+++ b/Prowl.Runtime.Generators/EquatableArray.cs
@@ -1,0 +1,56 @@
+// This file is part of the Prowl Game Engine
+// Licensed under the MIT License. See the LICENSE file in the project root for details.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Prowl.Generators;
+
+/// <summary>
+/// Value-equality wrapper around <c>T[]</c> for use in incremental generator
+/// pipeline models. The default array equality (reference) would defeat caching.
+/// </summary>
+internal readonly struct EquatableArray<T> : IEquatable<EquatableArray<T>>, IEnumerable<T>
+    where T : IEquatable<T>
+{
+    private readonly T[]? _array;
+
+    public EquatableArray(T[] array) => _array = array;
+
+    public int Length => _array?.Length ?? 0;
+
+    public T this[int index] => _array![index];
+
+    public bool Equals(EquatableArray<T> other)
+    {
+        if (ReferenceEquals(_array, other._array)) return true;
+        if (_array is null || other._array is null) return false;
+        if (_array.Length != other._array.Length) return false;
+        for (int i = 0; i < _array.Length; i++)
+        {
+            if (!_array[i].Equals(other._array[i]))
+                return false;
+        }
+        return true;
+    }
+
+    public override bool Equals(object? obj) => obj is EquatableArray<T> other && Equals(other);
+
+    public override int GetHashCode()
+    {
+        if (_array is null) return 0;
+        unchecked
+        {
+            int hash = 17;
+            for (int i = 0; i < _array.Length; i++)
+                hash = hash * 31 + _array[i].GetHashCode();
+            return hash;
+        }
+    }
+
+    public IEnumerator<T> GetEnumerator()
+        => ((IEnumerable<T>)(_array ?? Array.Empty<T>())).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/Prowl.Runtime.Generators/EventDomainGenerator.cs
+++ b/Prowl.Runtime.Generators/EventDomainGenerator.cs
@@ -1,0 +1,458 @@
+// This file is part of the Prowl Game Engine
+// Licensed under the MIT License. See the LICENSE file in the project root for details.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Prowl.Generators;
+
+[Generator]
+public class EventDomainGenerator : IIncrementalGenerator
+{
+    private const string EventDomainAttrFqn = "Prowl.Runtime.Events.EventDomainAttribute";
+    private const string EventArgsAttrFqn = "Prowl.Runtime.Events.EventArgsAttribute";
+    private const string EventKeyFqn = "global::Prowl.Runtime.Events.EventKey";
+    private const string UnitFqn = "global::Prowl.Runtime.Events.Unit";
+
+    private static readonly DiagnosticDescriptor s_notPartialDiag = new(
+        id: "PEVT0001",
+        title: "EventDomain class must be partial",
+        messageFormat: "The class '{0}' is marked with [EventDomain] but is not declared as 'partial'. Add the 'partial' modifier.",
+        category: "Prowl",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        var classDeclarations = context.SyntaxProvider
+            .ForAttributeWithMetadataName(
+                EventDomainAttrFqn,
+                predicate: static (node, _) => node is ClassDeclarationSyntax,
+                transform: static (ctx, ct) => GetDomainInfo(ctx, ct))
+            .Where(static m => m is not null);
+
+        context.RegisterSourceOutput(classDeclarations,
+            static (spc, domain) => Execute(spc, domain!.Value));
+    }
+
+    #region Data model (value-equatable for incremental caching)
+
+    private struct EventKeyInfo : IEquatable<EventKeyInfo>
+    {
+        public string Name;
+        public string ArgsTypeFqn;
+        public bool IsUnit;
+
+        public bool Equals(EventKeyInfo other)
+            => Name == other.Name
+            && ArgsTypeFqn == other.ArgsTypeFqn
+            && IsUnit == other.IsUnit;
+
+        public override bool Equals(object? obj) => obj is EventKeyInfo o && Equals(o);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int h = 17;
+                h = h * 31 + (Name?.GetHashCode() ?? 0);
+                h = h * 31 + (ArgsTypeFqn?.GetHashCode() ?? 0);
+                h = h * 31 + IsUnit.GetHashCode();
+                return h;
+            }
+        }
+    }
+
+    private struct ContainingTypeInfo : IEquatable<ContainingTypeInfo>
+    {
+        public string Keyword;       // "class", "struct", "record class", etc.
+        public string Name;
+        public string Accessibility;  // "public", "internal", etc.
+        public bool IsStatic;
+
+        public bool Equals(ContainingTypeInfo other)
+            => Keyword == other.Keyword
+            && Name == other.Name
+            && Accessibility == other.Accessibility
+            && IsStatic == other.IsStatic;
+
+        public override bool Equals(object? obj) => obj is ContainingTypeInfo o && Equals(o);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int h = 17;
+                h = h * 31 + (Keyword?.GetHashCode() ?? 0);
+                h = h * 31 + (Name?.GetHashCode() ?? 0);
+                h = h * 31 + (Accessibility?.GetHashCode() ?? 0);
+                h = h * 31 + IsStatic.GetHashCode();
+                return h;
+            }
+        }
+    }
+
+    private struct EventDomainInfo : IEquatable<EventDomainInfo>
+    {
+        public string? Namespace;
+        public string ClassName;
+        public string ClassAccessibility;
+        public bool IsStatic;
+        public bool IsGlobal;
+        public bool IsPartial;
+        public EquatableArray<ContainingTypeInfo> ContainingTypes;
+        public EquatableArray<EventKeyInfo> Events;
+        public Location? DiagnosticLocation;
+
+        public bool Equals(EventDomainInfo other)
+            => Namespace == other.Namespace
+            && ClassName == other.ClassName
+            && ClassAccessibility == other.ClassAccessibility
+            && IsStatic == other.IsStatic
+            && IsGlobal == other.IsGlobal
+            && IsPartial == other.IsPartial
+            && ContainingTypes.Equals(other.ContainingTypes)
+            && Events.Equals(other.Events);
+
+        public override bool Equals(object? obj) => obj is EventDomainInfo o && Equals(o);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int h = 17;
+                h = h * 31 + (Namespace?.GetHashCode() ?? 0);
+                h = h * 31 + (ClassName?.GetHashCode() ?? 0);
+                h = h * 31 + (ClassAccessibility?.GetHashCode() ?? 0);
+                h = h * 31 + IsStatic.GetHashCode();
+                h = h * 31 + IsGlobal.GetHashCode();
+                h = h * 31 + IsPartial.GetHashCode();
+                h = h * 31 + ContainingTypes.GetHashCode();
+                h = h * 31 + Events.GetHashCode();
+                return h;
+            }
+        }
+    }
+
+    #endregion
+
+    private static EventDomainInfo? GetDomainInfo(GeneratorAttributeSyntaxContext ctx, CancellationToken ct)
+    {
+        var classDecl = (ClassDeclarationSyntax)ctx.TargetNode;
+        var classSymbol = (INamedTypeSymbol)ctx.TargetSymbol;
+
+        bool isPartial = classDecl.Modifiers.Any(SyntaxKind.PartialKeyword);
+        bool isStatic = classSymbol.IsStatic;
+
+        // Extract Global property from [EventDomain] attribute
+        bool isGlobal = false;
+        foreach (var attrData in classSymbol.GetAttributes())
+        {
+            if (attrData.AttributeClass?.ToDisplayString() == "Prowl.Runtime.Events.EventDomainAttribute")
+            {
+                foreach (var namedArg in attrData.NamedArguments)
+                {
+                    if (namedArg.Key == "Global" && namedArg.Value.Value is bool g)
+                        isGlobal = g;
+                }
+                break;
+            }
+        }
+
+        // Collect EventKey fields with optional [EventArgs]
+        var events = new List<EventKeyInfo>();
+        foreach (var member in classSymbol.GetMembers())
+        {
+            ct.ThrowIfCancellationRequested();
+            if (member is IFieldSymbol field
+                && field.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == EventKeyFqn)
+            {
+                string argsType = UnitFqn; // default to Unit if no [EventArgs]
+                foreach (var attr in field.GetAttributes())
+                {
+                    if (attr.AttributeClass?.ToDisplayString() == "Prowl.Runtime.Events.EventArgsAttribute"
+                        && attr.ConstructorArguments.Length == 1
+                        && attr.ConstructorArguments[0].Value is ITypeSymbol typeArg
+                        && typeArg.TypeKind != TypeKind.Error)
+                    {
+                        argsType = typeArg.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+                        break;
+                    }
+                }
+
+                bool isUnit = argsType == UnitFqn;
+                string eventName = field.Name.StartsWith("_") ? field.Name.Substring(1) : field.Name;
+                events.Add(new EventKeyInfo
+                {
+                    Name = eventName,
+                    ArgsTypeFqn = argsType,
+                    IsUnit = isUnit,
+                });
+            }
+        }
+
+        if (events.Count == 0 && isPartial)
+            return null; // nothing to generate
+
+        // Collect containing type chain for nested classes
+        var containingTypes = new List<ContainingTypeInfo>();
+        var parent = classSymbol.ContainingType;
+        while (parent is not null)
+        {
+            containingTypes.Insert(0, new ContainingTypeInfo
+            {
+                Keyword = parent.IsRecord ? "record class" : "class",
+                Name = parent.Name,
+                Accessibility = AccessibilityToString(parent.DeclaredAccessibility),
+                IsStatic = parent.IsStatic,
+            });
+            parent = parent.ContainingType;
+        }
+
+        string? ns = classSymbol.ContainingNamespace.IsGlobalNamespace
+            ? null
+            : classSymbol.ContainingNamespace.ToDisplayString();
+
+        return new EventDomainInfo
+        {
+            Namespace = ns,
+            ClassName = classSymbol.Name,
+            ClassAccessibility = AccessibilityToString(classSymbol.DeclaredAccessibility),
+            IsStatic = isStatic,
+            IsGlobal = isGlobal,
+            IsPartial = isPartial,
+            ContainingTypes = new EquatableArray<ContainingTypeInfo>(containingTypes.ToArray()),
+            Events = new EquatableArray<EventKeyInfo>(events.ToArray()),
+            DiagnosticLocation = classDecl.Identifier.GetLocation(),
+        };
+    }
+
+    private static void Execute(SourceProductionContext spc, EventDomainInfo domain)
+    {
+        // Emit diagnostic if class is not partial
+        if (!domain.IsPartial)
+        {
+            spc.ReportDiagnostic(Diagnostic.Create(
+                s_notPartialDiag,
+                domain.DiagnosticLocation,
+                domain.ClassName));
+            return;
+        }
+
+        if (domain.Events.Length == 0)
+            return;
+
+        var sb = new StringBuilder();
+        sb.AppendLine("// <auto-generated/>");
+        sb.AppendLine("// Generated by Prowl.Runtime.Generators — do not edit.");
+        sb.AppendLine("#nullable enable");
+        sb.AppendLine();
+
+        if (domain.Namespace is not null)
+        {
+            sb.AppendLine($"namespace {domain.Namespace}");
+            sb.AppendLine("{");
+        }
+
+        string indent = domain.Namespace is not null ? "    " : "";
+
+        // Open containing types
+        foreach (var ct in domain.ContainingTypes)
+        {
+            string staticMod = ct.IsStatic ? " static" : "";
+            sb.AppendLine($"{indent}{ct.Accessibility}{staticMod} partial {ct.Keyword} {ct.Name}");
+            sb.AppendLine($"{indent}{{");
+            indent += "    ";
+        }
+
+        // Open the domain class
+        string classMods = domain.IsStatic ? " static" : "";
+        sb.AppendLine($"{indent}{domain.ClassAccessibility}{classMods} partial class {domain.ClassName}");
+        sb.AppendLine($"{indent}{{");
+        string ci = indent + "    "; // content indent
+
+        // --- Generate enum ---
+        sb.AppendLine($"{ci}/// <summary>Auto-generated enum backing the event keys in this domain.</summary>");
+        sb.AppendLine($"{ci}public enum EventTypes");
+        sb.AppendLine($"{ci}{{");
+        foreach (var evt in domain.Events)
+        {
+            sb.AppendLine($"{ci}    [global::Prowl.Runtime.Events.EventArgs(typeof({evt.ArgsTypeFqn}))]");
+            sb.AppendLine($"{ci}    {evt.Name},");
+        }
+        sb.AppendLine($"{ci}}}");
+        sb.AppendLine();
+
+        // --- Generate manager ---
+        string globalArg = domain.IsGlobal ? "global: true" : "";
+        string memberStatic = domain.IsStatic ? " static" : "";
+        string managerField = domain.IsStatic ? "s_eventManager" : "_eventManager";
+        string fieldDecl = domain.IsStatic ? "private static readonly" : "private readonly";
+        sb.AppendLine($"{ci}{fieldDecl} global::Prowl.Runtime.Events.EventManager<EventTypes> {managerField} = new({globalArg});");
+        sb.AppendLine();
+        sb.AppendLine($"{ci}/// <summary>Gets the <see cref=\"global::Prowl.Runtime.Events.EventManager{{T}}\"/> for this event domain. For instance domains, dispose this when the owner is no longer needed.</summary>");
+        sb.AppendLine($"{ci}public{memberStatic} global::Prowl.Runtime.Events.EventManager<EventTypes> Manager => {managerField};");
+        sb.AppendLine();
+
+        // --- Generate event accessor properties for += / -= subscription and .Invoke() ---
+        foreach (var evt in domain.Events)
+        {
+            string argsType = evt.ArgsTypeFqn;
+
+            if (evt.IsUnit)
+            {
+                sb.AppendLine($"{ci}/// <summary>Access <see cref=\"EventTypes.{evt.Name}\"/> using += / -= to subscribe, or .Invoke() to fire. For priority/tags/source capture or IDisposable container, use <c>{evt.Name}.Subscribe(...)</c> on this accessor.</summary>");
+                sb.AppendLine($"{ci}public{memberStatic} global::Prowl.Runtime.Events.EventAccessor<EventTypes> {evt.Name}");
+                sb.AppendLine($"{ci}{{");
+                sb.AppendLine($"{ci}    get => new({managerField}, EventTypes.{evt.Name});");
+                sb.AppendLine($"{ci}    set {{ }}");
+                sb.AppendLine($"{ci}}}");
+            }
+            else
+            {
+                sb.AppendLine($"{ci}/// <summary>Access <see cref=\"EventTypes.{evt.Name}\"/> using += / -= to subscribe, or .Invoke({argsType}) to fire. For priority/tags/source capture or IDisposable container, use <c>{evt.Name}.Subscribe(...)</c> on this accessor.</summary>");
+                sb.AppendLine($"{ci}public{memberStatic} global::Prowl.Runtime.Events.EventAccessor<EventTypes, {argsType}> {evt.Name}");
+                sb.AppendLine($"{ci}{{");
+                sb.AppendLine($"{ci}    get => new({managerField}, EventTypes.{evt.Name});");
+                sb.AppendLine($"{ci}    set {{ }}");
+                sb.AppendLine($"{ci}}}");
+            }
+        }
+        sb.AppendLine();
+
+        // --- Generate per-event convenience methods ---
+        foreach (var evt in domain.Events)
+        {
+            string argsType = evt.ArgsTypeFqn;
+
+            sb.AppendLine($"{ci}// --- {evt.Name} ---");
+            sb.AppendLine();
+
+            if (evt.IsUnit)
+            {
+                EmitUnitMethods(sb, ci, evt.Name, memberStatic, managerField);
+            }
+            else
+            {
+                EmitTypedMethods(sb, ci, evt.Name, argsType, memberStatic, managerField);
+            }
+        }
+
+        // --- Generate tag-based management methods ---
+        sb.AppendLine($"{ci}/// <summary>Enables all handlers in this domain that have the specified tag.</summary>");
+        sb.AppendLine($"{ci}public{memberStatic} void EnableByTag(string tag) => {managerField}.EnableByTag(tag);");
+        sb.AppendLine();
+        sb.AppendLine($"{ci}/// <summary>Disables all handlers in this domain that have the specified tag.</summary>");
+        sb.AppendLine($"{ci}public{memberStatic} void DisableByTag(string tag) => {managerField}.DisableByTag(tag);");
+        sb.AppendLine();
+        sb.AppendLine($"{ci}/// <summary>Removes all handlers in this domain that have the specified tag.</summary>");
+        sb.AppendLine($"{ci}public{memberStatic} void RemoveByTag(string tag) => {managerField}.RemoveByTag(tag);");
+        sb.AppendLine();
+        sb.AppendLine($"{ci}/// <summary>Enables all handlers across all global managers of this domain that have the specified tag.</summary>");
+        sb.AppendLine($"{ci}public static void GlobalEnableByTag(string tag) => global::Prowl.Runtime.Events.EventManager<EventTypes>.GlobalEnableByTag(tag);");
+        sb.AppendLine();
+        sb.AppendLine($"{ci}/// <summary>Disables all handlers across all global managers of this domain that have the specified tag.</summary>");
+        sb.AppendLine($"{ci}public static void GlobalDisableByTag(string tag) => global::Prowl.Runtime.Events.EventManager<EventTypes>.GlobalDisableByTag(tag);");
+        sb.AppendLine();
+        sb.AppendLine($"{ci}/// <summary>Removes all handlers across all global managers of this domain that have the specified tag.</summary>");
+        sb.AppendLine($"{ci}public static void GlobalRemoveByTag(string tag) => global::Prowl.Runtime.Events.EventManager<EventTypes>.GlobalRemoveByTag(tag);");
+        sb.AppendLine();
+
+        // Close domain class
+        sb.AppendLine($"{indent}}}");
+
+        // Close containing types
+        for (int i = domain.ContainingTypes.Length - 1; i >= 0; i--)
+        {
+            indent = indent.Substring(0, indent.Length - 4);
+            sb.AppendLine($"{indent}}}");
+        }
+
+        // Close namespace
+        if (domain.Namespace is not null)
+            sb.AppendLine("}");
+
+        string hintName = domain.ContainingTypes.Length > 0
+            ? string.Join(".", domain.ContainingTypes.Select(c => c.Name)) + "." + domain.ClassName + ".g.cs"
+            : domain.ClassName + ".g.cs";
+
+        spc.AddSource(hintName, sb.ToString());
+    }
+
+    private static void EmitUnitMethods(StringBuilder sb, string ci, string name, string memberStatic, string managerField)
+    {
+        // Invoke (parameterless)
+        sb.AppendLine($"{ci}/// <summary>Invokes <see cref=\"EventTypes.{name}\"/> on this domain's manager.</summary>");
+        sb.AppendLine($"{ci}[global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]");
+        sb.AppendLine($"{ci}public{memberStatic} void Invoke{name}()");
+        sb.AppendLine($"{ci}    => {managerField}.InvokeEvent(EventTypes.{name});");
+        sb.AppendLine();
+
+        // InvokeAsync (parameterless)
+        sb.AppendLine($"{ci}/// <summary>Asynchronously invokes <see cref=\"EventTypes.{name}\"/> on this domain's manager, awaiting async handlers.</summary>");
+        sb.AppendLine($"{ci}public{memberStatic} global::System.Threading.Tasks.Task Invoke{name}Async()");
+        sb.AppendLine($"{ci}    => {managerField}.InvokeEventAsync(EventTypes.{name});");
+        sb.AppendLine();
+
+        // GlobalInvoke (parameterless) — always static
+        sb.AppendLine($"{ci}/// <summary>Invokes <see cref=\"EventTypes.{name}\"/> across all global managers of this domain.</summary>");
+        sb.AppendLine($"{ci}[global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]");
+        sb.AppendLine($"{ci}public static void GlobalInvoke{name}()");
+        sb.AppendLine($"{ci}    => global::Prowl.Runtime.Events.EventManager<EventTypes>.GlobalInvokeEvent(EventTypes.{name});");
+        sb.AppendLine();
+
+        // GlobalInvokeAsync (parameterless) — always static
+        sb.AppendLine($"{ci}/// <summary>Asynchronously invokes <see cref=\"EventTypes.{name}\"/> across all global managers of this domain, awaiting async handlers.</summary>");
+        sb.AppendLine($"{ci}public static global::System.Threading.Tasks.Task GlobalInvoke{name}Async()");
+        sb.AppendLine($"{ci}    => global::Prowl.Runtime.Events.EventManager<EventTypes>.GlobalInvokeEventAsync(EventTypes.{name});");
+        sb.AppendLine();
+    }
+
+    private static void EmitTypedMethods(StringBuilder sb, string ci, string name, string argsType, string memberStatic, string managerField)
+    {
+        // Invoke (typed)
+        sb.AppendLine($"{ci}/// <summary>Invokes <see cref=\"EventTypes.{name}\"/> on this domain's manager.</summary>");
+        sb.AppendLine($"{ci}[global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]");
+        sb.AppendLine($"{ci}public{memberStatic} void Invoke{name}({argsType} args)");
+        sb.AppendLine($"{ci}    => {managerField}.InvokeEvent(EventTypes.{name}, args);");
+        sb.AppendLine();
+
+        // InvokeAsync (typed)
+        sb.AppendLine($"{ci}/// <summary>Asynchronously invokes <see cref=\"EventTypes.{name}\"/> on this domain's manager, awaiting async handlers.</summary>");
+        sb.AppendLine($"{ci}public{memberStatic} global::System.Threading.Tasks.Task Invoke{name}Async({argsType} args)");
+        sb.AppendLine($"{ci}    => {managerField}.InvokeEventAsync(EventTypes.{name}, args);");
+        sb.AppendLine();
+
+        // GlobalInvoke (typed) — always static
+        sb.AppendLine($"{ci}/// <summary>Invokes <see cref=\"EventTypes.{name}\"/> across all global managers of this domain.</summary>");
+        sb.AppendLine($"{ci}[global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]");
+        sb.AppendLine($"{ci}public static void GlobalInvoke{name}({argsType} args)");
+        sb.AppendLine($"{ci}    => global::Prowl.Runtime.Events.EventManager<EventTypes>.GlobalInvokeEvent(EventTypes.{name}, args);");
+        sb.AppendLine();
+
+        // GlobalInvokeAsync (typed) — always static
+        sb.AppendLine($"{ci}/// <summary>Asynchronously invokes <see cref=\"EventTypes.{name}\"/> across all global managers of this domain, awaiting async handlers.</summary>");
+        sb.AppendLine($"{ci}public static global::System.Threading.Tasks.Task GlobalInvoke{name}Async({argsType} args)");
+        sb.AppendLine($"{ci}    => global::Prowl.Runtime.Events.EventManager<EventTypes>.GlobalInvokeEventAsync(EventTypes.{name}, args);");
+        sb.AppendLine();
+    }
+
+    private static string AccessibilityToString(Accessibility accessibility) => accessibility switch
+    {
+        Accessibility.Public => "public",
+        Accessibility.Internal => "internal",
+        Accessibility.Protected => "protected",
+        Accessibility.ProtectedOrInternal => "protected internal",
+        Accessibility.ProtectedAndInternal => "private protected",
+        Accessibility.Private => "private",
+        _ => "internal",
+    };
+}

--- a/Prowl.Runtime.Generators/Prowl.Runtime.Generators.csproj
+++ b/Prowl.Runtime.Generators/Prowl.Runtime.Generators.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <IsRoslynComponent>true</IsRoslynComponent>
+    <NoWarn>RS2008</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/Prowl.Runtime/Components/GameCanvas.cs
+++ b/Prowl.Runtime/Components/GameCanvas.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 
 using Prowl.Echo;
+using Prowl.Runtime.Events;
 using Prowl.Runtime.GUI;
 using Prowl.Runtime.Rendering;
 using Prowl.Runtime.Resources;
@@ -190,13 +191,13 @@ public class GameCanvas : MonoBehaviour
     /// Overlay/Camera canvases ignore this hook — they are pulled by
     /// <see cref="UIRenderTree.CollectFor"/> from the pipeline directly.
     /// </summary>
-    public override void OnRenderCollect(Camera camera, List<IRenderable> renderables, List<IRenderableLight> _)
+    public override void OnRenderCollect(SceneEvents.OnRenderCollectArgs onRenderCollectArgs)
     {
         if (RenderMode != RenderMode.WorldSpace) return;
         RebuildIfDirty();
         Tree.RefreshTransforms();
         foreach (UIRenderItem it in Tree.Items)
-            renderables.Add(it);
+            onRenderCollectArgs.renderables.Add(it);
     }
 
     // ============================================================

--- a/Prowl.Runtime/Components/Lights/DirectionalLight.cs
+++ b/Prowl.Runtime/Components/Lights/DirectionalLight.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 
+using Prowl.Runtime.Events;
 using Prowl.Runtime.Rendering;
 using Prowl.Vector;
 
@@ -36,9 +37,9 @@ public class DirectionalLight : Light
     private Float4[] _cascadeAtlasParams = new Float4[4]; // xy = atlas pos, z = atlas size, w = split distance
     private int _activeCascades = 0;
 
-    public override void OnRenderCollect(Camera camera, List<IRenderable> renderables, List<IRenderableLight> lights)
+    public override void OnRenderCollect(SceneEvents.OnRenderCollectArgs args)
     {
-        lights.Add(this);
+        args.lights.Add(this);
     }
 
     public override void DrawGizmos()

--- a/Prowl.Runtime/Components/Lights/Light.cs
+++ b/Prowl.Runtime/Components/Lights/Light.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 
+using Prowl.Runtime.Events;
 using Prowl.Runtime.Rendering;
 using Prowl.Vector;
 
@@ -56,9 +57,9 @@ public abstract class Light : MonoBehaviour, IRenderableLight
     public int ShadowSlot { get; internal set; } = -1;
 
 
-    public override void OnRenderCollect(Camera camera, List<IRenderable> renderables, List<IRenderableLight> lights)
+    public override void OnRenderCollect(SceneEvents.OnRenderCollectArgs args)
     {
-        lights.Add(this);
+        args.lights.Add(this);
     }
 
     public virtual int GetLayer() => GameObject.LayerIndex;

--- a/Prowl.Runtime/Components/Lights/PointLight.cs
+++ b/Prowl.Runtime/Components/Lights/PointLight.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 
+using Prowl.Runtime.Events;
 using Prowl.Runtime.Rendering;
 using Prowl.Vector;
 
@@ -28,9 +29,9 @@ public class PointLight : Light
     private Float4x4[] _shadowMatrices = new Float4x4[6]; // View-projection for each face
     private bool _shadowsValid = false;
 
-    public override void OnRenderCollect(Camera camera, List<IRenderable> renderables, List<IRenderableLight> lights)
+    public override void OnRenderCollect(SceneEvents.OnRenderCollectArgs args)
     {
-        lights.Add(this);
+        args.lights.Add(this);
     }
 
     public override void DrawGizmos()

--- a/Prowl.Runtime/Components/Lights/SpotLight.cs
+++ b/Prowl.Runtime/Components/Lights/SpotLight.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 
+using Prowl.Runtime.Events;
 using Prowl.Runtime.Rendering;
 using Prowl.Vector;
 
@@ -28,9 +29,9 @@ public class SpotLight : Light
     private Float4x4 _shadowMatrix;
     private Float4 _shadowAtlasParams; // xy = atlas pos, z = atlas size, w = 1.0
 
-    public override void OnRenderCollect(Camera camera, List<IRenderable> renderables, List<IRenderableLight> lights)
+    public override void OnRenderCollect(SceneEvents.OnRenderCollectArgs args)
     {
-        lights.Add(this);
+        args.lights.Add(this);
     }
 
     public override void DrawGizmos()

--- a/Prowl.Runtime/Components/LineRenderer.cs
+++ b/Prowl.Runtime/Components/LineRenderer.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 
 using Prowl.Runtime.Rendering;
+using Prowl.Runtime.Events;
 using Prowl.Runtime.Resources;
 using Prowl.Vector;
 
@@ -84,10 +85,10 @@ public class LineRenderer : MonoBehaviour, IRenderable
         }
     }
 
-    public override void OnRenderCollect(Camera camera, List<IRenderable> renderables, List<IRenderableLight> lights)
+    public override void OnRenderCollect(SceneEvents.OnRenderCollectArgs args)
     {
         if (Material.Res != null && Points != null && Points.Count >= 2)
-            renderables.Add(this);
+            args.renderables.Add(this);
     }
 
     private bool PointsEqual(List<Float3> a, List<Float3> b)

--- a/Prowl.Runtime/Components/MeshRenderer.cs
+++ b/Prowl.Runtime/Components/MeshRenderer.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 
+using Prowl.Runtime.Events;
 using Prowl.Runtime.Rendering;
 using Prowl.Runtime.Resources;
 using Prowl.Vector;
@@ -36,7 +37,7 @@ public class MeshRenderer : MonoBehaviour
     /// <summary>UV2 → atlas transform: <c>uv2 * xy + zw</c>. Assigned by the lightmap bake.</summary>
     [HideInInspector] public Float4 LightmapScaleOffset = new(1, 1, 0, 0);
 
-    public override void OnRenderCollect(Camera camera, List<IRenderable> renderables, List<IRenderableLight> lights)
+    public override void OnRenderCollect(SceneEvents.OnRenderCollectArgs args)
     {
         var mesh = Mesh.Res;
         if (mesh == null || Materials.Count == 0) return;
@@ -62,7 +63,7 @@ public class MeshRenderer : MonoBehaviour
             Float3 giAnchor = Float4x4.TransformPoint(mesh.bounds.Center, Transform.LocalToWorldMatrix);
             LightmapBinding.Fill(props, GameObject.Scene, LightmapIndex, LightmapScaleOffset, giAnchor, mesh.HasUV2);
 
-            renderables.Add(new MeshRenderable(
+            args.renderables.Add(new MeshRenderable(
                 mesh, mat, Transform.LocalToWorldMatrix,
                 GameObject.LayerIndex, props, subMeshIndex: subCount > 1 ? s : -1));
         }

--- a/Prowl.Runtime/Components/ParticleSystem/ParticleSystemComponent.cs
+++ b/Prowl.Runtime/Components/ParticleSystem/ParticleSystemComponent.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 
+using Prowl.Runtime.Events;
 using Prowl.Runtime.Rendering;
 using Prowl.Runtime.Resources;
 using Prowl.Runtime.ParticleSystem.Modules;
@@ -155,7 +156,7 @@ public class ParticleSystemComponent : MonoBehaviour
         }
     }
 
-    public override void OnRenderCollect(Camera camera, List<IRenderable> renderables, List<IRenderableLight> lights)
+    public override void OnRenderCollect(SceneEvents.OnRenderCollectArgs args)
     {
         if (_particles.Count <= 0 || Material.Res == null || _quadMesh == null) return;
 
@@ -168,7 +169,7 @@ public class ParticleSystemComponent : MonoBehaviour
 
         // Create batched instanced renderables
         InstancedMeshRenderable.CreateBatched(
-            renderables,
+            args.renderables,
             _quadMesh,
             Material.Res,
             _transforms,
@@ -181,7 +182,7 @@ public class ParticleSystemComponent : MonoBehaviour
         );
 
         if (Light.Enabled)
-            CollectParticleLights(lights);
+            CollectParticleLights(args.lights);
     }
 
     /// <summary>

--- a/Prowl.Runtime/Components/SkinnedMeshRenderer.cs
+++ b/Prowl.Runtime/Components/SkinnedMeshRenderer.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 
 using Prowl.Echo;
+using Prowl.Runtime.Events;
 using Prowl.Runtime.Rendering;
 using Prowl.Runtime.Resources;
 using Prowl.Vector;
@@ -411,7 +412,7 @@ public class SkinnedMeshRenderer : MonoBehaviour
         _morphWeightTexture!.SetData<Float4>(data.AsMemory(0, _morphWeightCapacity), 0, 0, (uint)_morphWeightCapacity, 1);
     }
 
-    public override void OnRenderCollect(Camera camera, List<IRenderable> renderables, List<IRenderableLight> lights)
+    public override void OnRenderCollect(SceneEvents.OnRenderCollectArgs args)
     {
         var mesh = SharedMesh.Res;
         if (mesh == null || Materials.Count == 0) return;
@@ -470,7 +471,7 @@ public class SkinnedMeshRenderer : MonoBehaviour
             if (mesh.HasBlendShapes)
                 ApplyBlendShapeProps(mesh, props);
 
-            renderables.Add(new SkinnedMeshRenderable(
+            args.renderables.Add(new SkinnedMeshRenderable(
                 mesh, mat, Transform.LocalToWorldMatrix,
                 GameObject.LayerIndex, worldBounds, props, subMeshIndex: s));
         }

--- a/Prowl.Runtime/Components/Terrain/TerrainComponent.cs
+++ b/Prowl.Runtime/Components/Terrain/TerrainComponent.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 
+using Prowl.Runtime.Events;
 using Prowl.Runtime.Rendering;
 using Prowl.Runtime.Resources;
 using Prowl.Vector;
@@ -142,7 +143,7 @@ public class TerrainComponent : MonoBehaviour
     public Float3 WorldToTerrain(Float3 worldPoint) =>
         Float4x4.TransformPoint(worldPoint, Transform.WorldToLocalMatrix);
 
-    public override void OnRenderCollect(Camera camera, List<IRenderable> renderables, List<IRenderableLight> lights)
+    public override void OnRenderCollect(SceneEvents.OnRenderCollectArgs args)
     {
         var terrainData = Data.Res;
         if (terrainData == null) return;
@@ -152,7 +153,7 @@ public class TerrainComponent : MonoBehaviour
         Float4x4 worldToTerrain = Transform.WorldToLocalMatrix;
 
         // Camera position in terrain-local space for LOD
-        Float3 camLocal = WorldToTerrain(camera.Transform.Position);
+        Float3 camLocal = WorldToTerrain(args.camera.Transform.Position);
         camLocal.Y = 0;
 
         if (_quadtree == null
@@ -223,7 +224,7 @@ public class TerrainComponent : MonoBehaviour
         var bounds = TransformAABB(localMin, localMax, terrainToWorld);
 
         InstancedMeshRenderable.CreateBatched(
-            renderables, _baseMesh, mat, _transforms,
+            args.renderables, _baseMesh, mat, _transforms,
             (bounds.Min + bounds.Max) * 0.5f,
             layer: GameObject.LayerIndex,
             properties: _properties, bounds: bounds);
@@ -247,11 +248,11 @@ public class TerrainComponent : MonoBehaviour
             var htex = terrainData.GetHeightmapTexture();
             if (htex != null) grassMat.SetTexture("_Heightmap", htex);
 
-            _grassRenderer?.CollectRenderables(terrainData, this, camera, grassMat, GrassDistance, GrassDensityMultiplier, renderables);
+            _grassRenderer?.CollectRenderables(terrainData, this, args.camera, grassMat, GrassDistance, GrassDensityMultiplier, args.renderables);
         }
 
         // Trees
-        _treeRenderer?.CollectRenderables(terrainData, this, camera, TreeDistance, renderables);
+        _treeRenderer?.CollectRenderables(terrainData, this, args.camera, TreeDistance, args.renderables);
     }
 
     public override void DrawGizmos()

--- a/Prowl.Runtime/Components/WorldCanvas.cs
+++ b/Prowl.Runtime/Components/WorldCanvas.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 
 using Prowl.PaperUI;
 using Prowl.Runtime.GUI;
+using Prowl.Runtime.Events;
 using Prowl.Runtime.Rendering;
 using Prowl.Runtime.Resources;
 using Prowl.Vector;
@@ -103,7 +104,7 @@ public class WorldCanvas : MonoBehaviour, IRenderable
 
     }
 
-    public override void OnRenderCollect(Camera camera, List<IRenderable> renderables, List<IRenderableLight> lights)
+    public override void OnRenderCollect(SceneEvents.OnRenderCollectArgs args)
     {
         // Push this canvas as a renderable
         if (_renderTexture.IsValid() && (Material.Res?.IsValid() ?? false) && _quadMesh.IsValid())
@@ -111,7 +112,7 @@ public class WorldCanvas : MonoBehaviour, IRenderable
             _properties.Clear();
             _properties.SetInt("_ObjectID", InstanceID);
             _properties.SetTexture("_MainTex", _renderTexture.MainTexture);
-            renderables.Add(this);
+            args.renderables.Add(this);
         }
     }
 

--- a/Prowl.Runtime/Events/AsyncEventDelegateContainer.cs
+++ b/Prowl.Runtime/Events/AsyncEventDelegateContainer.cs
@@ -57,12 +57,12 @@ protected AsyncEventDelegateContainer(T eventType, ExecutionOrder priority,
 
     /// <summary>
     /// Synchronous invocation fallback. Fires the async handler without awaiting.
-    /// In DEBUG builds a warning is logged — prefer <see cref="InvokeAsync"/> instead.
+    /// When EVENT_DEBUG is defined, a warning is logged — prefer <see cref="InvokeAsync"/> instead.
     /// </summary>
     public override void Invoke(TArgs args)
     {
         if (!Enabled) return;
-#if DEBUG
+#if EVENT_DEBUG
         EventSystemDiagnostics.LogWarning?.Invoke(
             $"[EventSystem] Async handler on {typeof(T).Name} invoked synchronously. " +
             $"Use InvokeAsync/InvokeEventAsync for proper async execution. " +
@@ -112,7 +112,7 @@ public ParameterlessAsyncEventDelegateContainer(T eventType, Func<Task> asyncAct
     public override void Invoke(Unit args)
     {
         if (!Enabled) return;
-#if DEBUG
+#if EVENT_DEBUG
         EventSystemDiagnostics.LogWarning?.Invoke(
             $"[EventSystem] Async handler on {typeof(T).Name} invoked synchronously. " +
             $"Use InvokeAsync/InvokeEventAsync for proper async execution. " +

--- a/Prowl.Runtime/Events/AsyncEventDelegateContainer.cs
+++ b/Prowl.Runtime/Events/AsyncEventDelegateContainer.cs
@@ -1,0 +1,131 @@
+// This file is part of the Prowl Game Engine
+// Licensed under the MIT License. See the LICENSE file in the project root for details.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Prowl.Runtime.Events {
+
+/// <summary>
+/// Typed delegate container wrapping a <see cref="Func{TArgs, Task}"/> for async
+/// event handlers. Participates in the same priority-sorted snapshot as synchronous
+/// containers, enabling mixed sync/async handler chains.
+/// <para>
+/// When invoked via the synchronous <see cref="Invoke"/> path, the returned
+/// <see cref="Task"/> is observed but not awaited. Use
+/// <see cref="Event{T}.InvokeAsync{TArgs}"/> or the generated
+/// <c>InvokeXxxAsync</c> methods to properly await async handlers.
+/// </para>
+/// </summary>
+public class AsyncEventDelegateContainer<T, TArgs> : EventDelegateContainer<T, TArgs>, IAsyncInvocable<TArgs>
+    where T : struct, Enum
+{
+    /// <inheritdoc />
+    public override bool MatchesDelegate(Delegate handler) => handler != null && handler.Equals(_asyncDelegate);
+
+    private readonly Func<TArgs, Task>? _asyncDelegate;
+
+    public override Delegate? GetDelegate() => _asyncDelegate;
+
+    public AsyncEventDelegateContainer(T eventType, Func<TArgs, Task> asyncDelegate, ExecutionOrder priority = default, string[]? tags = null)
+        : base(eventType, priority, tags)
+    {
+        _asyncDelegate = asyncDelegate;
+    }
+
+public AsyncEventDelegateContainer(T eventType, Func<TArgs, Task> asyncDelegate, ExecutionOrder priority,
+    string? sourceFile, int sourceLine, string? sourceMember, string[]? tags = null)
+    : base(eventType, priority, sourceFile, sourceLine, sourceMember, tags)
+{
+    _asyncDelegate = asyncDelegate;
+}
+
+    /// <summary>
+    /// Protected constructor for subclasses that provide their own invocation
+    /// logic and do not use the <see cref="_asyncDelegate"/> field.
+    /// </summary>
+    protected AsyncEventDelegateContainer(T eventType, ExecutionOrder priority, string[]? tags = null)
+        : base(eventType, priority, tags)
+    {
+    }
+
+protected AsyncEventDelegateContainer(T eventType, ExecutionOrder priority,
+    string? sourceFile, int sourceLine, string? sourceMember, string[]? tags = null)
+    : base(eventType, priority, sourceFile, sourceLine, sourceMember, tags)
+{
+}
+
+    /// <summary>
+    /// Synchronous invocation fallback. Fires the async handler without awaiting.
+    /// In DEBUG builds a warning is logged — prefer <see cref="InvokeAsync"/> instead.
+    /// </summary>
+    public override void Invoke(TArgs args)
+    {
+        if (!Enabled) return;
+#if DEBUG
+        EventSystemDiagnostics.LogWarning?.Invoke(
+            $"[EventSystem] Async handler on {typeof(T).Name} invoked synchronously. " +
+            $"Use InvokeAsync/InvokeEventAsync for proper async execution. " +
+            $"Handler: {SourceDescription}");
+#endif
+        _asyncDelegate?.Invoke(args);
+    }
+
+    /// <summary>
+    /// Asynchronously invokes the handler and returns the resulting <see cref="Task"/>.
+    /// </summary>
+    public virtual Task InvokeAsync(TArgs args)
+    {
+        if (!Enabled) return Task.CompletedTask;
+        return _asyncDelegate?.Invoke(args) ?? Task.CompletedTask;
+    }
+}
+
+/// <summary>
+/// Specialized container for parameterless async events that stores a
+/// <see cref="Func{Task}"/> directly, avoiding the closure allocation that
+/// wrapping in a <see cref="Func{Unit, Task}"/> would incur.
+/// </summary>
+public sealed class ParameterlessAsyncEventDelegateContainer<T> : AsyncEventDelegateContainer<T, Unit>
+    where T : struct, Enum
+{
+    /// <inheritdoc />
+    public override bool MatchesDelegate(Delegate handler) => handler != null && handler.Equals(_asyncAction);
+
+    private readonly Func<Task> _asyncAction;
+
+    public override Delegate? GetDelegate() => _asyncAction;
+
+    public ParameterlessAsyncEventDelegateContainer(T eventType, Func<Task> asyncAction, ExecutionOrder priority = default, string[]? tags = null)
+        : base(eventType, priority, tags)
+    {
+        _asyncAction = asyncAction;
+    }
+
+public ParameterlessAsyncEventDelegateContainer(T eventType, Func<Task> asyncAction, ExecutionOrder priority,
+    string? sourceFile, int sourceLine, string? sourceMember, string[]? tags = null)
+    : base(eventType, priority, sourceFile, sourceLine, sourceMember, tags)
+{
+    _asyncAction = asyncAction;
+}
+
+    public override void Invoke(Unit args)
+    {
+        if (!Enabled) return;
+#if DEBUG
+        EventSystemDiagnostics.LogWarning?.Invoke(
+            $"[EventSystem] Async handler on {typeof(T).Name} invoked synchronously. " +
+            $"Use InvokeAsync/InvokeEventAsync for proper async execution. " +
+            $"Handler: {SourceDescription}");
+#endif
+        _asyncAction?.Invoke();
+    }
+
+    public override Task InvokeAsync(Unit args)
+    {
+        if (!Enabled) return Task.CompletedTask;
+        return _asyncAction?.Invoke() ?? Task.CompletedTask;
+    }
+}
+
+}

--- a/Prowl.Runtime/Events/Event.cs
+++ b/Prowl.Runtime/Events/Event.cs
@@ -25,10 +25,10 @@ public class Event<T> where T : struct, Enum
         public static readonly bool IsCancellable = typeof(ICancellable).IsAssignableFrom(typeof(TArgs));
     }
 
-#if DEBUG
+#if EVENT_DEBUG
     /// <summary>
     /// Configurable threshold in milliseconds. Handlers exceeding this duration
-    /// will be logged as warnings in DEBUG builds. Set to 0 to disable.
+    /// will be logged as warnings when EVENT_DEBUG is defined. Set to 0 to disable.
     /// </summary>
     public static double SlowHandlerThresholdMs { get; set; } = 200.0;
 #endif
@@ -46,7 +46,7 @@ public class Event<T> where T : struct, Enum
     /// <summary>
     /// Copy-on-write snapshot: a flat, priority-sorted array of all delegates.
     /// Rebuilt only when the subscriber list changes (Add/Remove), never on Invoke.
-    /// Used by DEBUG diagnostics to detect type-mismatch handlers.
+    /// Used by EVENT_DEBUG diagnostics to detect type-mismatch handlers.
     /// </summary>
     private EventDelegateContainer<T>[] _cachedSnapshot = [];
 
@@ -135,10 +135,10 @@ public class Event<T> where T : struct, Enum
     public void Invoke<TArgs>(TArgs args)
     {
         if (!Enabled) return;
-        
+
             EventDelegateContainer<T, TArgs>[] typedSnapshot;
             int typedLength;
-#if DEBUG
+#if EVENT_DEBUG
             EventDelegateContainer<T>[] fullSnapshot;
             int fullLength;
 #endif
@@ -154,13 +154,13 @@ public class Event<T> where T : struct, Enum
                     typedSnapshot = [];
                     typedLength = 0;
                 }
-#if DEBUG
+#if EVENT_DEBUG
                 fullSnapshot = _cachedSnapshot;
                 fullLength = _cachedSnapshotLength;
 #endif
             }
 
-#if DEBUG
+#if EVENT_DEBUG
             // Warn about handlers on this event registered with a different TArgs.
             if (fullLength > typedLength)
             {
@@ -177,7 +177,7 @@ public class Event<T> where T : struct, Enum
             var span = typedSnapshot.AsSpan(0, typedLength);
             for (int j = 0; j < span.Length; j++)
             {
-#if DEBUG
+#if EVENT_DEBUG
                 sw?.Restart();
 #endif
                 try
@@ -189,7 +189,7 @@ public class Event<T> where T : struct, Enum
                     Console.WriteLine();
                 }
 
-#if DEBUG
+#if EVENT_DEBUG
                 if (sw is not null)
                 {
                     sw.Stop();
@@ -207,7 +207,7 @@ public class Event<T> where T : struct, Enum
                 if (CancellableCheck<TArgs>.IsCancellable && args is ICancellable { Cancelled: true })
                     break;
             }
-        
+
 
     }
 
@@ -227,7 +227,7 @@ public class Event<T> where T : struct, Enum
 
         EventDelegateContainer<T, TArgs>[] typedSnapshot;
         int typedLength;
-#if DEBUG
+#if EVENT_DEBUG
         EventDelegateContainer<T>[] fullSnapshot;
         int fullLength;
 #endif
@@ -243,13 +243,13 @@ public class Event<T> where T : struct, Enum
                 typedSnapshot = [];
                 typedLength = 0;
             }
-#if DEBUG
+#if EVENT_DEBUG
             fullSnapshot = _cachedSnapshot;
             fullLength = _cachedSnapshotLength;
 #endif
         }
 
-#if DEBUG
+#if EVENT_DEBUG
         // Warn about handlers on this event registered with a different TArgs.
         if (fullLength > typedLength)
         {
@@ -266,7 +266,7 @@ public class Event<T> where T : struct, Enum
 
         for (int j = 0; j < typedLength; j++)
         {
-#if DEBUG
+#if EVENT_DEBUG
             sw?.Restart();
 #endif
             try
@@ -281,7 +281,7 @@ public class Event<T> where T : struct, Enum
                 Console.WriteLine(ex.Message);
             }
 
-#if DEBUG
+#if EVENT_DEBUG
             if (sw is not null)
             {
                 sw.Stop();
@@ -322,10 +322,10 @@ public class Event<T> where T : struct, Enum
         }
     }
 
-#if DEBUG
+#if EVENT_DEBUG
     /// <summary>
     /// Logs a warning when a registered handler is skipped because its TArgs
-    /// does not match the invoked type. Only compiled into DEBUG builds.
+    /// does not match the invoked type. Only compiled when EVENT_DEBUG is defined.
     /// </summary>
     private void WarnTypeMismatch<TArgs>(EventDelegateContainer<T> container)
     {

--- a/Prowl.Runtime/Events/Event.cs
+++ b/Prowl.Runtime/Events/Event.cs
@@ -1,0 +1,647 @@
+// This file is part of the Prowl Game Engine
+// Licensed under the MIT License. See the LICENSE file in the project root for details.
+
+using System;
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace Prowl.Runtime.Events;
+
+public class Event<T> where T : struct, Enum
+{
+    /// <summary>
+    /// JIT-time cache: <c>true</c> when <typeparamref name="TArgs"/> implements
+    /// <see cref="ICancellable"/>. Evaluated once per closed generic and stored in a
+    /// static field, so the hot-path <see cref="Invoke{TArgs}"/> never boxes value-type
+    /// args just to check the interface.
+    /// </summary>
+    private static class CancellableCheck<TArgs>
+    {
+        public static readonly bool IsCancellable = typeof(ICancellable).IsAssignableFrom(typeof(TArgs));
+    }
+
+#if DEBUG
+    /// <summary>
+    /// Configurable threshold in milliseconds. Handlers exceeding this duration
+    /// will be logged as warnings in DEBUG builds. Set to 0 to disable.
+    /// </summary>
+    public static double SlowHandlerThresholdMs { get; set; } = 200.0;
+#endif
+
+    private readonly T _eventType;
+    public T EventType => _eventType;
+
+    private readonly EventManager<T> _eventManager;
+    public EventManager<T> EventManager => _eventManager;
+
+    private readonly List<EventDelegateContainer<T>> _delegates = [];
+
+    private readonly object _lock = new();
+
+    /// <summary>
+    /// Copy-on-write snapshot: a flat, priority-sorted array of all delegates.
+    /// Rebuilt only when the subscriber list changes (Add/Remove), never on Invoke.
+    /// Used by DEBUG diagnostics to detect type-mismatch handlers.
+    /// </summary>
+    private EventDelegateContainer<T>[] _cachedSnapshot = [];
+
+    /// <summary>
+    /// Actual valid length of <see cref="_cachedSnapshot"/> when rented from ArrayPool.
+    /// The rented array may be larger than needed; use this length for iteration.
+    /// </summary>
+    private int _cachedSnapshotLength = 0;
+
+    /// <summary>
+    /// Per-<c>TArgs</c> typed COW snapshots keyed by <see cref="Type"/>.
+    /// Each value is a <c>EventDelegateContainer&lt;T, TArgs&gt;[]</c> stored as
+    /// <see cref="object"/>.
+    /// <para>
+    /// <see cref="Invoke{TArgs}"/> retrieves the matching typed array with a single
+    /// dictionary lookup and one array-reference cast — <b>no per-element type check</b>.
+    /// </para>
+    /// </summary>
+    private readonly ConcurrentDictionary<Type, object> _typedSnapshots = new();
+
+    /// <summary>
+    /// Per-<c>TArgs</c> actual lengths of typed snapshots. Since typed arrays
+    /// are rented from ArrayPool, they may be larger than needed.
+    /// </summary>
+    private readonly ConcurrentDictionary<Type, int> _typedSnapshotLengths = new();
+
+    private volatile bool _enabled = true;
+    public bool Enabled
+    {
+        get => _enabled;
+        set => _enabled = value;
+    }
+
+    /// <summary>
+    /// When greater than zero, snapshot rebuilds are deferred until the batch
+    /// count returns to zero. Incremented by <see cref="BeginBatch"/> and
+    /// decremented by <see cref="EndBatch"/>. Must only be accessed under <see cref="_lock"/>.
+    /// </summary>
+    private int _batchDepth;
+
+    /// <summary>
+    /// Tracks whether any Add/Remove occurred while batching was active,
+    /// so that <see cref="EndBatch"/> knows whether a rebuild is needed.
+    /// </summary>
+    private bool _batchDirty;
+
+    public Event(EventManager<T> eventManager, T eventType)
+    {
+        this._eventType = eventType;
+        this._eventManager = eventManager;
+    }
+
+    /// <summary>
+    /// Begins a batch operation. While batched, <see cref="Add"/> and <see cref="Remove"/>
+    /// will not rebuild snapshots. Call <see cref="EndBatch"/> when finished to rebuild once.
+    /// Calls may be nested; only the outermost <see cref="EndBatch"/> triggers the rebuild.
+    /// </summary>
+    public void BeginBatch()
+    {
+        lock (_lock)
+        {
+            _batchDepth++;
+        }
+    }
+
+    /// <summary>
+    /// Ends a batch operation. If this is the outermost batch and any mutations
+    /// occurred, the COW snapshot is rebuilt exactly once.
+    /// </summary>
+    public void EndBatch()
+    {
+        lock (_lock)
+        {
+            if (_batchDepth > 0)
+                _batchDepth--;
+
+            if (_batchDepth == 0 && _batchDirty)
+            {
+                _batchDirty = false;
+                RebuildSnapshot();
+            }
+        }
+    }
+
+
+    public void Invoke<TArgs>(TArgs args)
+    {
+        if (!Enabled) return;
+        
+            EventDelegateContainer<T, TArgs>[] typedSnapshot;
+            int typedLength;
+#if DEBUG
+            EventDelegateContainer<T>[] fullSnapshot;
+            int fullLength;
+#endif
+            lock (_lock)
+            {
+                if (_typedSnapshots.TryGetValue(typeof(TArgs), out object? obj))
+                {
+                    typedSnapshot = (EventDelegateContainer<T, TArgs>[])obj;
+                    typedLength = _typedSnapshotLengths[typeof(TArgs)];
+                }
+                else
+                {
+                    typedSnapshot = [];
+                    typedLength = 0;
+                }
+#if DEBUG
+                fullSnapshot = _cachedSnapshot;
+                fullLength = _cachedSnapshotLength;
+#endif
+            }
+
+#if DEBUG
+            // Warn about handlers on this event registered with a different TArgs.
+            if (fullLength > typedLength)
+            {
+                for (int j = 0; j < fullLength; j++)
+                {
+                    if (fullSnapshot[j] is not EventDelegateContainer<T, TArgs>)
+                        WarnTypeMismatch<TArgs>(fullSnapshot[j]);
+                }
+            }
+
+            double threshold = SlowHandlerThresholdMs;
+            Stopwatch? sw = threshold > 0 ? Stopwatch.StartNew() : null;
+#endif
+            var span = typedSnapshot.AsSpan(0, typedLength);
+            for (int j = 0; j < span.Length; j++)
+            {
+#if DEBUG
+                sw?.Restart();
+#endif
+                try
+                {
+                    span[j].Invoke(args);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine();
+                }
+
+#if DEBUG
+                if (sw is not null)
+                {
+                    sw.Stop();
+                    double elapsed = sw.Elapsed.TotalMilliseconds;
+                    if (elapsed > threshold)
+                    {
+                        EventSystemDiagnostics.LogWarning?.Invoke(
+                            $"[EventSystem] Slow handler on {typeof(T).Name}.{_eventType}: " +
+                            $"{elapsed:F2}ms (threshold {threshold:F1}ms). " +
+                            $"Handler: {typedSnapshot[j].SourceDescription}");
+                    }
+                }
+#endif
+
+                if (CancellableCheck<TArgs>.IsCancellable && args is ICancellable { Cancelled: true })
+                    break;
+            }
+        
+
+    }
+
+    /// <summary>
+    /// Asynchronously invokes all handlers for the given <typeparamref name="TArgs"/>,
+    /// awaiting async handlers (<see cref="IAsyncInvocable{TArgs}"/>) sequentially while
+    /// calling synchronous handlers inline. Priority ordering and cancellation semantics
+    /// are identical to <see cref="Invoke{TArgs}"/>.
+    /// <para>
+    /// Intended for editor/tool events where handlers legitimately need to perform I/O.
+    /// Not recommended for the game-loop hot path — use <see cref="Invoke{TArgs}"/> instead.
+    /// </para>
+    /// </summary>
+    public async Task InvokeAsync<TArgs>(TArgs args)
+    {
+        if (!Enabled) return;
+
+        EventDelegateContainer<T, TArgs>[] typedSnapshot;
+        int typedLength;
+#if DEBUG
+        EventDelegateContainer<T>[] fullSnapshot;
+        int fullLength;
+#endif
+        lock (_lock)
+        {
+            if (_typedSnapshots.TryGetValue(typeof(TArgs), out object? obj))
+            {
+                typedSnapshot = (EventDelegateContainer<T, TArgs>[])obj;
+                typedLength = _typedSnapshotLengths[typeof(TArgs)];
+            }
+            else
+            {
+                typedSnapshot = [];
+                typedLength = 0;
+            }
+#if DEBUG
+            fullSnapshot = _cachedSnapshot;
+            fullLength = _cachedSnapshotLength;
+#endif
+        }
+
+#if DEBUG
+        // Warn about handlers on this event registered with a different TArgs.
+        if (fullLength > typedLength)
+        {
+            for (int j = 0; j < fullLength; j++)
+            {
+                if (fullSnapshot[j] is not EventDelegateContainer<T, TArgs>)
+                    WarnTypeMismatch<TArgs>(fullSnapshot[j]);
+            }
+        }
+
+        double threshold = SlowHandlerThresholdMs;
+        Stopwatch? sw = threshold > 0 ? Stopwatch.StartNew() : null;
+#endif
+
+        for (int j = 0; j < typedLength; j++)
+        {
+#if DEBUG
+            sw?.Restart();
+#endif
+            try
+            {
+                if (typedSnapshot[j] is IAsyncInvocable<TArgs> asyncHandler)
+                    await asyncHandler.InvokeAsync(args).ConfigureAwait(false);
+                else
+                    typedSnapshot[j].Invoke(args);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+            }
+
+#if DEBUG
+            if (sw is not null)
+            {
+                sw.Stop();
+                double elapsed = sw.Elapsed.TotalMilliseconds;
+                if (elapsed > threshold)
+                {
+                    EventSystemDiagnostics.LogWarning?.Invoke(
+                        $"[EventSystem] Slow handler on {typeof(T).Name}.{_eventType}: " +
+                        $"{elapsed:F2}ms (threshold {threshold:F1}ms). " +
+                        $"Handler: {typedSnapshot[j].SourceDescription}");
+                }
+            }
+#endif
+
+            if (CancellableCheck<TArgs>.IsCancellable && args is ICancellable { Cancelled: true })
+                break;
+        }
+
+    }
+
+    /// <summary>
+    /// Returns a read-only view of the currently registered handlers for the
+    /// given <typeparamref name="TArgs"/> type, sorted by priority.
+    /// The span references a COW snapshot — it is safe to read after the lock
+    /// is released but may become stale if handlers are added or removed.
+    /// </summary>
+    public ReadOnlySpan<EventDelegateContainer<T, TArgs>> GetHandlers<TArgs>()
+    {
+        lock (_lock)
+        {
+            if (_typedSnapshots.TryGetValue(typeof(TArgs), out object? obj))
+            {
+                var array = (EventDelegateContainer<T, TArgs>[])obj;
+                int length = _typedSnapshotLengths[typeof(TArgs)];
+                return array.AsSpan(0, length);
+            }
+            return ReadOnlySpan<EventDelegateContainer<T, TArgs>>.Empty;
+        }
+    }
+
+#if DEBUG
+    /// <summary>
+    /// Logs a warning when a registered handler is skipped because its TArgs
+    /// does not match the invoked type. Only compiled into DEBUG builds.
+    /// </summary>
+    private void WarnTypeMismatch<TArgs>(EventDelegateContainer<T> container)
+    {
+        // Extract the registered TArgs from the concrete generic type.
+        Type containerType = container.GetType();
+        Type? registeredArgs = null;
+        if (containerType.IsGenericType && containerType.GenericTypeArguments.Length == 2)
+            registeredArgs = containerType.GenericTypeArguments[1];
+
+        EventSystemDiagnostics.LogWarning?.Invoke(
+            $"[EventSystem] Type mismatch on {typeof(T).Name}.{_eventType}: " +
+            $"handler registered for '{registeredArgs?.Name ?? "unknown"}' " +
+            $"but invoked with '{typeof(TArgs).Name}'. Handler was skipped. " +
+            $"(registered at {container.SourceDescription})");
+    }
+#endif
+
+    public bool Add(EventDelegateContainer<T> eventDelegate, bool allowMultiple = false)
+    {
+        bool added = false;
+
+        lock (_lock)
+        {
+            if (allowMultiple || !ContainsDelegate(eventDelegate.GetDelegate()))
+            {
+                // Binary search for insertion point to maintain sorted order by priority.
+                // Uses upper-bound semantics so equal priorities preserve insertion order (stable).
+                int lo = 0, hi = _delegates.Count;
+                while (lo < hi)
+                {
+                    int mid = (lo + hi) >>> 1;
+                    if (_delegates[mid].Priority.CompareTo(eventDelegate.Priority) <= 0)
+                        lo = mid + 1;
+                    else
+                        hi = mid;
+                }
+                _delegates.Insert(lo, eventDelegate);
+                eventDelegate.Link(this);
+                added = true;
+            }
+            if (added)
+            {
+                if (_batchDepth > 0)
+                    _batchDirty = true;
+                else
+                    RebuildSnapshot();
+            }
+            eventDelegate.Added = added;
+            return added;
+        }
+    }
+
+    public bool Remove(EventDelegateContainer<T> eventDelegate)
+    {
+        lock (_lock)
+        {
+            bool result = _delegates.Remove(eventDelegate);
+            if (result)
+            {
+                eventDelegate.Unlink();
+                if (_batchDepth > 0)
+                    _batchDirty = true;
+                else
+                    RebuildSnapshot();
+            }
+            return result;
+        }
+    }
+
+    /// <summary>
+    /// Removes the first delegate container whose wrapped handler equals the
+    /// specified <paramref name="handler"/>. Used by generated <c>-=</c> event accessors.
+    /// </summary>
+    public bool RemoveByDelegate(Delegate handler)
+    {
+        lock (_lock)
+        {
+            for (int i = 0; i < _delegates.Count; i++)
+            {
+                if (_delegates[i].MatchesDelegate(handler))
+                {
+                    EventDelegateContainer<T> container = _delegates[i];
+                    _delegates.RemoveAt(i);
+                    container.Unlink();
+                    if (_batchDepth > 0)
+                        _batchDirty = true;
+                    else
+                        RebuildSnapshot();
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    private bool ContainsDelegate(Delegate? handler)
+    {
+        if (handler == null) return false;
+        for (int i = 0; i < _delegates.Count; i++)
+        {
+            if (_delegates[i].MatchesDelegate(handler)) return true;
+        }
+        return false;
+    }
+
+    public void EnableByTag(string tag)
+    {
+        lock (_lock)
+        {
+            foreach (var del in _delegates)
+            {
+                if (del.HasTag(tag)) del.Enable();
+            }
+        }
+    }
+
+    public void DisableByTag(string tag)
+    {
+        lock (_lock)
+        {
+            foreach (var del in _delegates)
+            {
+                if (del.HasTag(tag)) del.Disable();
+            }
+        }
+    }
+
+    public void RemoveByTag(string tag)
+    {
+        lock (_lock)
+        {
+            bool removed = false;
+            for (int i = _delegates.Count - 1; i >= 0; i--)
+            {
+                if (_delegates[i].HasTag(tag))
+                {
+                    var container = _delegates[i];
+                    _delegates.RemoveAt(i);
+                    container.Unlink();
+                    removed = true;
+                }
+            }
+
+            if (removed)
+            {
+                if (_batchDepth > 0)
+                    _batchDirty = true;
+                else
+                    RebuildSnapshot();
+            }
+        }
+    }
+
+
+    /// <summary>
+    /// Rebuilds the flat, priority-sorted snapshot array and per-<c>TArgs</c> typed
+    /// snapshot arrays from the current delegate list.
+    /// Must be called under <see cref="_lock"/>.
+    /// </summary>
+    private void RebuildSnapshot()
+    {
+        int totalCount = _delegates.Count;
+
+        if (totalCount == 0)
+        {
+            // Return old snapshot to pool before clearing
+            if (_cachedSnapshot.Length > 0)
+                ArrayPool<EventDelegateContainer<T>>.Shared.Return(_cachedSnapshot, clearArray: true);
+
+            _cachedSnapshot = [];
+            _cachedSnapshotLength = 0;
+            _typedSnapshots.Clear();
+            _typedSnapshotLengths.Clear();
+            return;
+        }
+
+        // Return old snapshot to pool before renting new one
+        if (_cachedSnapshot.Length > 0)
+            ArrayPool<EventDelegateContainer<T>>.Shared.Return(_cachedSnapshot, clearArray: true);
+
+        // Rent from ArrayPool instead of allocating
+        EventDelegateContainer<T>[] snapshot = ArrayPool<EventDelegateContainer<T>>.Shared.Rent(totalCount);
+        for (int i = 0; i < totalCount; i++)
+            snapshot[i] = _delegates[i];
+        _cachedSnapshot = snapshot;
+        _cachedSnapshotLength = totalCount;
+
+        RebuildTypedSnapshots();
+    }
+
+    /// <summary>
+    /// Rebuilds per-<c>TArgs</c> typed snapshot arrays from the priority-sorted
+    /// delegate buckets.  Each resulting array is a properly typed
+    /// <c>EventDelegateContainer&lt;T, TArgs&gt;[]</c>, enabling
+    /// <see cref="Invoke{TArgs}"/> to iterate with direct method calls and
+    /// zero per-element type checks.
+    /// Must be called under <see cref="_lock"/>.
+    /// </summary>
+    private void RebuildTypedSnapshots()
+    {
+        // Return all old typed snapshots to their respective pools
+        foreach (var kvp in _typedSnapshots)
+        {
+            Type argsType = kvp.Key;
+            if (!s_arrayReturnMethods.TryGetValue(argsType, out Action<object>? returnMethod))
+            {
+                returnMethod = CreateArrayReturnMethod(argsType);
+                s_arrayReturnMethods[argsType] = returnMethod;
+            }
+            returnMethod(kvp.Value);
+        }
+
+        _typedSnapshots.Clear();
+        _typedSnapshotLengths.Clear();
+
+        // First pass: collect containers per ArgsType, maintaining priority order.
+        Dictionary<Type, List<EventDelegateContainer<T>>>? groups = null;
+
+        for (int i = 0; i < _delegates.Count; i++)
+        {
+            EventDelegateContainer<T> container = _delegates[i];
+            Type argsType = container.ArgsType;
+
+            groups ??= new Dictionary<Type, List<EventDelegateContainer<T>>>();
+            if (!groups.TryGetValue(argsType, out List<EventDelegateContainer<T>>? list))
+            {
+                list = new List<EventDelegateContainer<T>>();
+                groups[argsType] = list;
+            }
+            list.Add(container);
+        }
+
+        if (groups is null)
+            return;
+
+        // Second pass: create properly typed arrays via cached generic delegates,
+        // avoiding Array.CreateInstance + per-element SetValue overhead.
+        foreach (KeyValuePair<Type, List<EventDelegateContainer<T>>> entry in groups)
+        {
+            if (!s_arrayBuilders.TryGetValue(entry.Key, out Func<List<EventDelegateContainer<T>>, object>? builder))
+            {
+                builder = CreateArrayBuilder(entry.Key);
+                s_arrayBuilders[entry.Key] = builder;
+            }
+            _typedSnapshots[entry.Key] = builder(entry.Value);
+            _typedSnapshotLengths[entry.Key] = entry.Value.Count;
+        }
+    }
+
+    /// <summary>
+    /// Generic helper invoked through a cached delegate.  Creates a strongly typed
+    /// array and populates it with simple reference casts — no <see cref="Array.SetValue(object, int)"/>
+    /// overhead.
+    /// </summary>
+    private static object BuildTypedArray<TArgs>(List<EventDelegateContainer<T>> list)
+    {
+        // Rent from ArrayPool instead of allocating
+        EventDelegateContainer<T, TArgs>[] result = ArrayPool<EventDelegateContainer<T, TArgs>>.Shared.Rent(list.Count);
+        for (int i = 0; i < list.Count; i++)
+            result[i] = (EventDelegateContainer<T, TArgs>)list[i];
+        return result;
+    }
+
+    /// <summary>
+    /// Generic helper invoked through a cached delegate. Returns a rented typed array
+    /// to its <c>ArrayPool&lt;EventDelegateContainer&lt;T, TArgs&gt;&gt;.Shared</c>.
+    /// </summary>
+    private static void ReturnTypedArray<TArgs>(object array)
+    {
+        ArrayPool<EventDelegateContainer<T, TArgs>>.Shared.Return(
+            (EventDelegateContainer<T, TArgs>[])array, clearArray: true);
+    }
+
+    /// <summary>
+    /// Creates and returns a delegate that calls <see cref="BuildTypedArray{TArgs}"/>
+    /// closed over the given <paramref name="argsType"/>.  The reflection cost is paid
+    /// once; subsequent rebuilds reuse the cached delegate.
+    /// </summary>
+    private static Func<List<EventDelegateContainer<T>>, object> CreateArrayBuilder(Type argsType)
+    {
+        MethodInfo openMethod = typeof(Event<T>)
+            .GetMethod(nameof(BuildTypedArray), BindingFlags.NonPublic | BindingFlags.Static)!;
+#pragma warning disable IL3050 // MakeGenericMethod: the closed generic is only over reference-compatible types already loaded.
+        MethodInfo closedMethod = openMethod.MakeGenericMethod(argsType);
+#pragma warning restore IL3050
+        return (Func<List<EventDelegateContainer<T>>, object>)
+            Delegate.CreateDelegate(typeof(Func<List<EventDelegateContainer<T>>, object>), closedMethod);
+    }
+
+    /// <summary>
+    /// Creates and returns a delegate that calls <see cref="ReturnTypedArray{TArgs}"/>
+    /// closed over the given <paramref name="argsType"/>. Used to return rented arrays
+    /// to the appropriate ArrayPool instance.
+    /// </summary>
+    private static Action<object> CreateArrayReturnMethod(Type argsType)
+    {
+        MethodInfo openMethod = typeof(Event<T>)
+            .GetMethod(nameof(ReturnTypedArray), BindingFlags.NonPublic | BindingFlags.Static)!;
+#pragma warning disable IL3050 // MakeGenericMethod: the closed generic is only over reference-compatible types already loaded.
+        MethodInfo closedMethod = openMethod.MakeGenericMethod(argsType);
+#pragma warning restore IL3050
+        return (Action<object>)
+            Delegate.CreateDelegate(typeof(Action<object>), closedMethod);
+    }
+
+    /// <summary>
+    /// Per-<c>TArgs</c> cached factory delegates that build strongly typed
+    /// <c>EventDelegateContainer&lt;T, TArgs&gt;[]</c> from a list of base containers.
+    /// Avoids repeated <see cref="Array.CreateInstance(Type, int)"/> and per-element
+    /// <see cref="Array.SetValue(object, int)"/> overhead.
+    /// </summary>
+    private static readonly ConcurrentDictionary<Type, Func<List<EventDelegateContainer<T>>, object>> s_arrayBuilders = new();
+
+    /// <summary>
+    /// Per-<c>TArgs</c> cached methods that return rented arrays to the appropriate
+    /// <c>ArrayPool&lt;EventDelegateContainer&lt;T, TArgs&gt;&gt;.Shared</c>.
+    /// </summary>
+    private static readonly ConcurrentDictionary<Type, Action<object>> s_arrayReturnMethods = new();
+}

--- a/Prowl.Runtime/Events/EventAccessor.cs
+++ b/Prowl.Runtime/Events/EventAccessor.cs
@@ -68,8 +68,9 @@ public readonly struct EventAccessor<TEnum> where TEnum : struct, Enum
         [CallerFilePath] string? sourceFile = null,
         [CallerLineNumber] int sourceLine = 0,
         [CallerMemberName] string? sourceMember = null,
-        string[]? tags = null)
-        => _manager.AddNewDelegate(_eventType, handler, order, sourceFile, sourceLine, sourceMember, false, tags);
+        string[]? tags = null,
+        bool allowMultiple = false)
+        => _manager.AddNewDelegate(_eventType, handler, order, sourceFile, sourceLine, sourceMember, allowMultiple, tags);
 
     /// <summary>
     /// Subscribes a parameterless async handler to the event. Supports order, tags, and source location capture.
@@ -80,8 +81,9 @@ public readonly struct EventAccessor<TEnum> where TEnum : struct, Enum
         [CallerFilePath] string? sourceFile = null,
         [CallerLineNumber] int sourceLine = 0,
         [CallerMemberName] string? sourceMember = null,
-        string[]? tags = null)
-        => _manager.AddNewAsyncDelegate(_eventType, handler, order, sourceFile, sourceLine, sourceMember, false, tags);
+        string[]? tags = null,
+        bool allowMultiple = false)
+        => _manager.AddNewAsyncDelegate(_eventType, handler, order, sourceFile, sourceLine, sourceMember, allowMultiple, tags);
 
     /// <summary>
     /// Subscribes a parameterless handler that automatically unsubscribes after one invocation.
@@ -150,8 +152,9 @@ public readonly struct EventAccessor<TEnum, TArgs> where TEnum : struct, Enum
         [CallerFilePath] string? sourceFile = null,
         [CallerLineNumber] int sourceLine = 0,
         [CallerMemberName] string? sourceMember = null,
-        string[]? tags = null)
-        => _manager.AddNewDelegate<TArgs>(_eventType, handler, order, sourceFile, sourceLine, sourceMember, false, tags);
+        string[]? tags = null,
+        bool allowMultiple = false)
+        => _manager.AddNewDelegate<TArgs>(_eventType, handler, order, sourceFile, sourceLine, sourceMember, allowMultiple, tags);
 
     /// <summary>
     /// Subscribes a typed async handler to the event. Supports order, tags, and source location capture.
@@ -162,8 +165,9 @@ public readonly struct EventAccessor<TEnum, TArgs> where TEnum : struct, Enum
         [CallerFilePath] string? sourceFile = null,
         [CallerLineNumber] int sourceLine = 0,
         [CallerMemberName] string? sourceMember = null,
-        string[]? tags = null)
-        => _manager.AddNewAsyncDelegate<TArgs>(_eventType, handler, order, sourceFile, sourceLine, sourceMember, false, tags);
+        string[]? tags = null,
+        bool allowMultiple = false)
+        => _manager.AddNewAsyncDelegate<TArgs>(_eventType, handler, order, sourceFile, sourceLine, sourceMember, allowMultiple, tags);
 
     /// <summary>
     /// Subscribes a typed handler that automatically unsubscribes after one invocation.

--- a/Prowl.Runtime/Events/EventAccessor.cs
+++ b/Prowl.Runtime/Events/EventAccessor.cs
@@ -1,0 +1,180 @@
+// This file is part of the Prowl Game Engine
+// Licensed under the MIT License. See the LICENSE file in the project root for details.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+namespace Prowl.Runtime.Events {
+
+/// <summary>
+/// Lightweight accessor for a parameterless event slot.
+/// Supports <c>+=</c> / <c>-=</c> for subscribe/unsubscribe and
+/// <see cref="Invoke"/> for firing the event.
+/// </summary>
+/// <remarks>
+/// This is a <see langword="readonly struct"/> returned by generated event
+/// properties. The no-op setter on the property allows
+/// <c>Domain.OnFoo += handler</c> to compile (expands to
+/// <c>Domain.OnFoo = Domain.OnFoo + handler</c>).
+/// </remarks>
+public readonly struct EventAccessor<TEnum> where TEnum : struct, Enum
+{
+    private readonly EventManager<TEnum> _manager;
+    private readonly TEnum _eventType;
+
+    public EventAccessor(EventManager<TEnum> manager, TEnum eventType)
+    {
+        _manager = manager;
+        _eventType = eventType;
+    }
+
+    /// <summary>Fire the parameterless event.</summary>
+    public void Invoke() => _manager.InvokeEvent(_eventType);
+
+    /// <summary>Asynchronously fire the parameterless event, awaiting async handlers.</summary>
+    public Task InvokeAsync() => _manager.InvokeEventAsync(_eventType);
+
+    public static EventAccessor<TEnum> operator +(EventAccessor<TEnum> accessor, Action handler)
+    {
+        accessor._manager.AddNewDelegate(accessor._eventType, handler, default(ExecutionOrder));
+        return accessor;
+    }
+
+    public static EventAccessor<TEnum> operator -(EventAccessor<TEnum> accessor, Action handler)
+    {
+        accessor._manager.RemoveDelegate(accessor._eventType, handler);
+        return accessor;
+    }
+
+    public static EventAccessor<TEnum> operator +(EventAccessor<TEnum> accessor, Func<Task> handler)
+    {
+        accessor._manager.AddNewAsyncDelegate(accessor._eventType, handler, default(ExecutionOrder));
+        return accessor;
+    }
+
+    public static EventAccessor<TEnum> operator -(EventAccessor<TEnum> accessor, Func<Task> handler)
+    {
+        accessor._manager.RemoveDelegate(accessor._eventType, handler);
+        return accessor;
+    }
+
+    /// <summary>
+    /// Subscribes a parameterless handler to the event. Supports order, tags, and source location capture.
+    /// Dispose the returned container to unsubscribe.
+    /// </summary>
+    public EventDelegateContainer<TEnum, Unit> Subscribe(
+        Action handler, ExecutionOrder order = default,
+        [CallerFilePath] string? sourceFile = null,
+        [CallerLineNumber] int sourceLine = 0,
+        [CallerMemberName] string? sourceMember = null,
+        string[]? tags = null)
+        => _manager.AddNewDelegate(_eventType, handler, order, sourceFile, sourceLine, sourceMember, false, tags);
+
+    /// <summary>
+    /// Subscribes a parameterless async handler to the event. Supports order, tags, and source location capture.
+    /// Dispose the returned container to unsubscribe.
+    /// </summary>
+    public AsyncEventDelegateContainer<TEnum, Unit> SubscribeAsync(
+        Func<Task> handler, ExecutionOrder order = default,
+        [CallerFilePath] string? sourceFile = null,
+        [CallerLineNumber] int sourceLine = 0,
+        [CallerMemberName] string? sourceMember = null,
+        string[]? tags = null)
+        => _manager.AddNewAsyncDelegate(_eventType, handler, order, sourceFile, sourceLine, sourceMember, false, tags);
+
+    /// <summary>
+    /// Subscribes a parameterless handler that automatically unsubscribes after one invocation.
+    /// </summary>
+    public OneTimeParameterlessEventDelegateContainer<TEnum> SubscribeOnce(
+        Action handler, ExecutionOrder order = default,
+        [CallerFilePath] string? sourceFile = null,
+        [CallerLineNumber] int sourceLine = 0,
+        [CallerMemberName] string? sourceMember = null,
+        string[]? tags = null)
+        => _manager.SubscribeOnce(_eventType, handler, order, sourceFile, sourceLine, sourceMember, tags);
+}
+
+/// <summary>
+/// Lightweight accessor for a typed event slot.
+/// Supports <c>+=</c> / <c>-=</c> for subscribe/unsubscribe and
+/// <see cref="Invoke"/> for firing the event with arguments.
+/// </summary>
+public readonly struct EventAccessor<TEnum, TArgs> where TEnum : struct, Enum
+{
+    private readonly EventManager<TEnum> _manager;
+    private readonly TEnum _eventType;
+
+    public EventAccessor(EventManager<TEnum> manager, TEnum eventType)
+    {
+        _manager = manager;
+        _eventType = eventType;
+    }
+
+    /// <summary>Fire the event with the given arguments.</summary>
+    public void Invoke(TArgs args) => _manager.InvokeEvent<TArgs>(_eventType, args);
+
+    /// <summary>Asynchronously fire the event with the given arguments, awaiting async handlers.</summary>
+    public Task InvokeAsync(TArgs args) => _manager.InvokeEventAsync<TArgs>(_eventType, args);
+
+    public static EventAccessor<TEnum, TArgs> operator +(EventAccessor<TEnum, TArgs> accessor, Action<TArgs> handler)
+    {
+        accessor._manager.AddNewDelegate<TArgs>(accessor._eventType, handler, default(ExecutionOrder));
+        return accessor;
+    }
+
+    public static EventAccessor<TEnum, TArgs> operator -(EventAccessor<TEnum, TArgs> accessor, Action<TArgs> handler)
+    {
+        accessor._manager.RemoveDelegate(accessor._eventType, handler);
+        return accessor;
+    }
+
+    public static EventAccessor<TEnum, TArgs> operator +(EventAccessor<TEnum, TArgs> accessor, Func<TArgs, Task> handler)
+    {
+        accessor._manager.AddNewAsyncDelegate<TArgs>(accessor._eventType, handler, default(ExecutionOrder));
+        return accessor;
+    }
+
+    public static EventAccessor<TEnum, TArgs> operator -(EventAccessor<TEnum, TArgs> accessor, Func<TArgs, Task> handler)
+    {
+        accessor._manager.RemoveDelegate(accessor._eventType, handler);
+        return accessor;
+    }
+
+    /// <summary>
+    /// Subscribes a typed handler to the event. Supports order, tags, and source location capture.
+    /// Dispose the returned container to unsubscribe.
+    /// </summary>
+    public EventDelegateContainer<TEnum, TArgs> Subscribe(
+        Action<TArgs> handler, ExecutionOrder order = default,
+        [CallerFilePath] string? sourceFile = null,
+        [CallerLineNumber] int sourceLine = 0,
+        [CallerMemberName] string? sourceMember = null,
+        string[]? tags = null)
+        => _manager.AddNewDelegate<TArgs>(_eventType, handler, order, sourceFile, sourceLine, sourceMember, false, tags);
+
+    /// <summary>
+    /// Subscribes a typed async handler to the event. Supports order, tags, and source location capture.
+    /// Dispose the returned container to unsubscribe.
+    /// </summary>
+    public AsyncEventDelegateContainer<TEnum, TArgs> SubscribeAsync(
+        Func<TArgs, Task> handler, ExecutionOrder order = default,
+        [CallerFilePath] string? sourceFile = null,
+        [CallerLineNumber] int sourceLine = 0,
+        [CallerMemberName] string? sourceMember = null,
+        string[]? tags = null)
+        => _manager.AddNewAsyncDelegate<TArgs>(_eventType, handler, order, sourceFile, sourceLine, sourceMember, false, tags);
+
+    /// <summary>
+    /// Subscribes a typed handler that automatically unsubscribes after one invocation.
+    /// </summary>
+    public OneTimeEventDelegateContainer<TEnum, TArgs> SubscribeOnce(
+        Action<TArgs> handler, ExecutionOrder order = default,
+        [CallerFilePath] string? sourceFile = null,
+        [CallerLineNumber] int sourceLine = 0,
+        [CallerMemberName] string? sourceMember = null,
+        string[]? tags = null)
+        => _manager.SubscribeOnce<TArgs>(_eventType, handler, order, sourceFile, sourceLine, sourceMember, tags);
+}
+
+}

--- a/Prowl.Runtime/Events/EventArgsAttribute.cs
+++ b/Prowl.Runtime/Events/EventArgsAttribute.cs
@@ -1,0 +1,28 @@
+// This file is part of the Prowl Game Engine
+// Licensed under the MIT License. See the LICENSE file in the project root for details.
+
+using System;
+
+namespace Prowl.Runtime.Events {
+
+/// <summary>
+/// Declares the canonical <c>TArgs</c> type for an event enum value.
+/// When present, <see cref="EventManager{T}.AddNewDelegate{TArgs}"/> and
+/// <see cref="EventManager{T}.InvokeEvent{TArgs}"/> will assert that the
+/// supplied <c>TArgs</c> matches the declared type.
+/// <para>
+/// Omitting the attribute on a value means "any TArgs is accepted" (opt-in safety).
+/// </para>
+/// </summary>
+[AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = false)]
+public sealed class EventArgsAttribute : Attribute
+{
+    public Type ArgsType { get; }
+
+    public EventArgsAttribute(Type argsType)
+    {
+        ArgsType = argsType ?? throw new ArgumentNullException(nameof(argsType));
+    }
+}
+
+}

--- a/Prowl.Runtime/Events/EventArgsContract.cs
+++ b/Prowl.Runtime/Events/EventArgsContract.cs
@@ -1,0 +1,61 @@
+// This file is part of the Prowl Game Engine
+// Licensed under the MIT License. See the LICENSE file in the project root for details.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Prowl.Runtime.Events;
+
+/// <summary>
+/// Builds and caches a mapping from each <typeparamref name="T"/> enum value
+/// to the <see cref="Type"/> declared by its <see cref="EventArgsAttribute"/>
+/// (if any). Evaluated once per closed generic <c>T</c>.
+/// </summary>
+internal static class EventArgsContract<T> where T : struct, Enum
+{
+    /// <summary>
+    /// Maps each enum value to its declared <c>TArgs</c> type, or <c>null</c>
+    /// if the value has no <see cref="EventArgsAttribute"/>.
+    /// </summary>
+    private static readonly Dictionary<T, Type?> s_declaredArgs = Build();
+
+    private static Dictionary<T, Type?> Build()
+    {
+        Dictionary<T, Type?> map = new Dictionary<T, Type?>();
+        Type enumType = typeof(T);
+
+        foreach (T value in Enum.GetValues<T>())
+        {
+            string name = Enum.GetName(value)!;
+            FieldInfo? field = enumType.GetField(name);
+            EventArgsAttribute? attr = field?.GetCustomAttribute<EventArgsAttribute>();
+            map[value] = attr?.ArgsType;
+        }
+
+        return map;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when <typeparamref name="TArgs"/> is compatible
+    /// with the contract declared on <paramref name="eventType"/>.
+    /// Returns <c>true</c> when no attribute is present (opt-in model).
+    /// </summary>
+    public static bool IsValid<TArgs>(T eventType)
+    {
+        if (!s_declaredArgs.TryGetValue(eventType, out Type? declared) || declared is null)
+            return true;
+
+        return declared == typeof(TArgs);
+    }
+
+    /// <summary>
+    /// Returns the declared type name for diagnostics, or <c>"(none)"</c>.
+    /// </summary>
+    public static string GetDeclaredName(T eventType)
+    {
+        if (s_declaredArgs.TryGetValue(eventType, out Type? declared) && declared is not null)
+            return declared.Name;
+        return "(none)";
+    }
+}

--- a/Prowl.Runtime/Events/EventDelegateContainer.cs
+++ b/Prowl.Runtime/Events/EventDelegateContainer.cs
@@ -67,7 +67,7 @@ public abstract class EventDelegateContainer<T> : IEventDelegateContainer where 
 
 /// <summary>
 /// Source file where this handler was registered. Captured automatically
-/// via <see cref="CallerFilePathAttribute"/> in DEBUG builds.
+/// via <see cref="CallerFilePathAttribute"/> when EVENT_DEBUG is defined.
 /// </summary>
 public string? SourceFile { get; private set; }
 
@@ -124,7 +124,7 @@ public string SourceDescription =>
     protected EventDelegateContainer(T eventType, ExecutionOrder priority, string? sourceFile, int sourceLine, string? sourceMember, string[]? tags = null)
         : this(eventType, priority, tags)
     {
-#if DEBUG
+#if EVENT_DEBUG
         SourceFile = sourceFile is not null ? System.IO.Path.GetFileName(sourceFile) : null;
         SourceLine = sourceLine;
         SourceMember = sourceMember;

--- a/Prowl.Runtime/Events/EventDelegateContainer.cs
+++ b/Prowl.Runtime/Events/EventDelegateContainer.cs
@@ -1,0 +1,292 @@
+// This file is part of the Prowl Game Engine
+// Licensed under the MIT License. See the LICENSE file in the project root for details.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Prowl.Runtime.Events {
+
+/// <summary>
+/// Non-generic base class for delegate containers, enabling heterogeneous storage
+/// within a single <see cref="Event{T}"/>. Subscribe via the typed
+/// <see cref="EventDelegateContainer{T, TArgs}"/> derived class.
+/// Implements <see cref="IDisposable"/> for self-unsubscription.
+/// </summary>
+public abstract class EventDelegateContainer<T> : IEventDelegateContainer where T : struct, Enum
+{
+    public EventManager<T>? EventManager => Event?.EventManager;
+
+    private Event<T> _event;
+    public Event<T> Event
+    {
+        get { return _event; }
+        private set
+        {
+            _event = value;
+        }
+    }
+
+    private bool _added;
+    public bool Added
+    {
+        get { return _added; }
+        internal set { _added = value; }
+    }
+
+    private bool _disposed;
+
+    private readonly T eventType;
+    public T EventType => eventType;
+
+    private bool enabled = true;
+    public bool Enabled
+    {
+        get => enabled;
+        private set => enabled = value;
+    }
+
+    private readonly ExecutionOrder priority;
+    public ExecutionOrder Priority => priority;
+
+    /// <summary>
+    /// The <c>TArgs</c> type this container was registered with.
+    /// Used by <see cref="Event{T}"/> to build per-type snapshots without reflection.
+    /// </summary>
+    public abstract Type ArgsType { get; }
+
+    /// <summary>
+    /// Returns the underlying delegate wrapped by this container.
+    /// </summary>
+    public abstract Delegate? GetDelegate();
+
+    /// <summary>
+    /// Returns <c>true</c> when this container wraps the specified handler delegate.
+    /// Used by the generated <c>-=</c> event accessor path.
+    /// </summary>
+    public abstract bool MatchesDelegate(Delegate handler);
+
+/// <summary>
+/// Source file where this handler was registered. Captured automatically
+/// via <see cref="CallerFilePathAttribute"/> in DEBUG builds.
+/// </summary>
+public string? SourceFile { get; private set; }
+
+/// <summary>
+/// Source line number where this handler was registered.
+/// </summary>
+public int SourceLine { get; private set; }
+
+/// <summary>
+/// Name of the member that registered this handler.
+/// </summary>
+public string? SourceMember { get; private set; }
+
+/// <summary>
+/// Returns a compact "File:Line (Member)" string for diagnostics,
+/// or <c>"unknown"</c> when source info was not captured.
+/// </summary>
+public string SourceDescription =>
+    SourceFile is not null
+        ? $"{SourceFile}:{SourceLine} ({SourceMember})"
+        : "unknown";
+
+    public void Link(Event<T> @event)
+    {
+        Event = @event;
+    }
+
+    public void Unlink()
+    {
+        Event = null;
+    }
+
+    private string[]? _tags;
+    public string[]? Tags => _tags;
+
+    public bool HasTag(string tag)
+    {
+        if (_tags == null) return false;
+        for (int i = 0; i < _tags.Length; i++)
+        {
+            if (string.Equals(_tags[i], tag, StringComparison.Ordinal))
+                return true;
+        }
+        return false;
+    }
+
+    protected EventDelegateContainer(T eventType, ExecutionOrder priority, string[]? tags = null)
+    {
+        this.priority = priority;
+        this.eventType = eventType;
+        this._tags = tags;
+    }
+
+    protected EventDelegateContainer(T eventType, ExecutionOrder priority, string? sourceFile, int sourceLine, string? sourceMember, string[]? tags = null)
+        : this(eventType, priority, tags)
+    {
+#if DEBUG
+        SourceFile = sourceFile is not null ? System.IO.Path.GetFileName(sourceFile) : null;
+        SourceLine = sourceLine;
+        SourceMember = sourceMember;
+#endif
+    }
+
+    public void Enable()
+    {
+        Enabled = true;
+    }
+    public void Disable()
+    {
+        Enabled = false;
+    }
+
+    /// <summary>
+    /// Removes this delegate from its parent event, enabling <c>using</c> patterns
+    /// and preventing leaks.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed) return;
+
+        _disposed = true;
+        Event?.Remove(this);
+    }
+}
+
+/// <summary>
+/// Typed delegate container wrapping an <see cref="Action{TArgs}"/>.
+/// </summary>
+public class EventDelegateContainer<T, TArgs> : EventDelegateContainer<T>, IInvocable<TArgs> where T : struct, Enum
+{
+    public override Type ArgsType => typeof(TArgs);
+
+    /// <inheritdoc />
+    public override bool MatchesDelegate(Delegate handler) => handler != null && handler.Equals(eventDelegate);
+
+    private readonly Action<TArgs>? eventDelegate;
+
+    public override Delegate? GetDelegate() => eventDelegate;
+
+    public EventDelegateContainer(T eventType, Action<TArgs> eventDelegate, ExecutionOrder priority = default, string[]? tags = null)
+        : base(eventType, priority, tags)
+    {
+        this.eventDelegate = eventDelegate;
+    }
+
+public EventDelegateContainer(T eventType, Action<TArgs> eventDelegate, ExecutionOrder priority,
+    string? sourceFile, int sourceLine, string? sourceMember, string[]? tags = null)
+    : base(eventType, priority, sourceFile, sourceLine, sourceMember, tags)
+{
+    this.eventDelegate = eventDelegate;
+}
+
+    /// <summary>
+    /// Protected constructor for subclasses that provide their own invocation
+    /// logic and do not use the <see cref="eventDelegate"/> field.
+    /// </summary>
+    protected EventDelegateContainer(T eventType, ExecutionOrder priority, string[]? tags = null)
+        : base(eventType, priority, tags)
+    {
+    }
+
+protected EventDelegateContainer(T eventType, ExecutionOrder priority,
+    string? sourceFile, int sourceLine, string? sourceMember, string[]? tags = null)
+    : base(eventType, priority, sourceFile, sourceLine, sourceMember, tags)
+{
+}
+
+public virtual void Invoke(TArgs args)
+    {
+        if (!Enabled) return;
+        eventDelegate?.Invoke(args);
+    }
+}
+
+/// <summary>
+/// Specialized container for parameterless events that stores an <see cref="Action"/>
+/// directly, avoiding the closure allocation that wrapping in an
+/// <see cref="Action{Unit}"/> would incur.
+/// </summary>
+public sealed class ParameterlessEventDelegateContainer<T> : EventDelegateContainer<T, Unit> where T : struct, Enum
+{
+    /// <inheritdoc />
+    public override bool MatchesDelegate(Delegate handler) => handler != null && handler.Equals(_action);
+
+    private readonly Action _action;
+
+    public override Delegate? GetDelegate() => _action;
+
+    public ParameterlessEventDelegateContainer(T eventType, Action action, ExecutionOrder priority = default, string[]? tags = null)
+        : base(eventType, priority, tags)
+    {
+        _action = action;
+    }
+
+public ParameterlessEventDelegateContainer(T eventType, Action action, ExecutionOrder priority,
+    string? sourceFile, int sourceLine, string? sourceMember, string[]? tags = null)
+    : base(eventType, priority, sourceFile, sourceLine, sourceMember, tags)
+{
+    _action = action;
+}
+
+    public override void Invoke(Unit args)
+    {
+        if (!Enabled) return;
+        _action?.Invoke();
+    }
+}
+
+/// <summary>
+/// A typed delegate container that automatically disposes itself after a single invocation.
+/// </summary>
+public sealed class OneTimeEventDelegateContainer<T, TArgs> : EventDelegateContainer<T, TArgs> where T : struct, Enum
+{
+    private readonly Action<TArgs>? _eventDelegate;
+
+    public override Delegate? GetDelegate() => _eventDelegate;
+
+    public override Type ArgsType => typeof(TArgs);
+    public override bool MatchesDelegate(Delegate handler) => handler != null && handler.Equals(_eventDelegate);
+
+    public OneTimeEventDelegateContainer(T eventType, Action<TArgs> eventDelegate, ExecutionOrder priority,
+        string? sourceFile, int sourceLine, string? sourceMember, string[]? tags = null)
+        : base(eventType, priority, sourceFile, sourceLine, sourceMember, tags)
+    {
+        _eventDelegate = eventDelegate;
+    }
+
+    public override void Invoke(TArgs args)
+    {
+        if (!Enabled) return;
+        _eventDelegate?.Invoke(args);
+        Dispose();
+    }
+}
+
+/// <summary>
+/// A parameterless delegate container that automatically disposes itself after a single invocation.
+/// </summary>
+public sealed class OneTimeParameterlessEventDelegateContainer<T> : EventDelegateContainer<T, Unit> where T : struct, Enum
+{
+    private readonly Action _action;
+
+    public override Delegate? GetDelegate() => _action;
+
+    public override bool MatchesDelegate(Delegate handler) => handler != null && handler.Equals(_action);
+
+    public OneTimeParameterlessEventDelegateContainer(T eventType, Action action, ExecutionOrder priority,
+        string? sourceFile, int sourceLine, string? sourceMember, string[]? tags = null)
+        : base(eventType, priority, sourceFile, sourceLine, sourceMember, tags)
+    {
+        _action = action;
+    }
+
+    public override void Invoke(Unit args)
+    {
+        if (!Enabled) return;
+        _action?.Invoke();
+        Dispose();
+    }
+}
+
+}

--- a/Prowl.Runtime/Events/EventDomainAttribute.cs
+++ b/Prowl.Runtime/Events/EventDomainAttribute.cs
@@ -1,0 +1,66 @@
+// This file is part of the Prowl Game Engine
+// Licensed under the MIT License. See the LICENSE file in the project root for details.
+
+using System;
+
+namespace Prowl.Runtime.Events {
+
+/// <summary>
+/// Marks a <c>partial class</c> as an event domain.
+/// The source generator will produce a backing enum, an <see cref="EventManager{T}"/>,
+/// event accessor properties, and typed <c>Invoke*</c> / <c>GlobalInvoke*</c> convenience methods
+/// for each <see cref="EventKey"/> field. Advanced subscriptions are available on the accessors
+/// via <c>.Subscribe(...)</c> etc.
+/// <para>
+/// <b>Static domains</b> (the class is <c>static</c>) produce a single shared
+/// <see cref="EventManager{T}"/> and static convenience methods — ideal for
+/// global engine events.
+/// </para>
+/// <para>
+/// <b>Instance domains</b> (the class is <em>not</em> <c>static</c>) produce a
+/// per-instance <see cref="EventManager{T}"/> and instance convenience methods —
+/// ideal for component-level or per-object events. Dispose <see cref="EventManager{T}"/>
+/// via <c>Manager.Dispose()</c> when the owner is no longer needed.
+/// <c>GlobalInvoke</c> methods remain static and broadcast across all global managers.
+/// </para>
+/// <para>
+/// <b>Static example:</b>
+/// <code>
+/// [EventDomain(Global = true)]
+/// public static partial class MyEvents
+/// {
+///     [EventArgs(typeof(MyArgs))]
+///     private static readonly EventKey _OnSomething = new();
+///
+///     public readonly struct MyArgs { public int Value; }
+/// }
+/// // Usage: MyEvents.InvokeOnSomething(args);
+/// </code>
+/// </para>
+/// <para>
+/// <b>Instance example:</b>
+/// <code>
+/// [EventDomain]
+/// public partial class ActorEvents
+/// {
+///     [EventArgs(typeof(DamageArgs))]
+///     private static readonly EventKey _OnDamaged = new();
+///
+///     public readonly record struct DamageArgs(float Amount);
+/// }
+/// // Usage: actor.InvokeOnDamaged(new DamageArgs(10));
+/// </code>
+/// </para>
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+public sealed class EventDomainAttribute : Attribute
+{
+    /// <summary>
+    /// When <c>true</c>, the generated <see cref="EventManager{T}"/> is created
+    /// with <c>global: true</c>, making it participate in
+    /// <see cref="EventManager{T}.GlobalInvokeEvent"/> calls.
+    /// </summary>
+    public bool Global { get; set; }
+}
+
+}

--- a/Prowl.Runtime/Events/EventKey.cs
+++ b/Prowl.Runtime/Events/EventKey.cs
@@ -1,0 +1,30 @@
+// This file is part of the Prowl Game Engine
+// Licensed under the MIT License. See the LICENSE file in the project root for details.
+
+namespace Prowl.Runtime.Events {
+
+/// <summary>
+/// Marker type for source-generated event domains.
+/// Declare <c>private static readonly EventKey _OnXxx</c> fields inside a class marked with
+/// <see cref="EventDomainAttribute"/> to define events. The leading underscore is stripped
+/// by the generator to produce the public event name. Optionally decorate each
+/// field with <see cref="EventArgsAttribute"/> to specify the event's argument type
+/// (defaults to <see cref="Unit"/> when omitted).
+/// <para>
+/// <b>Example:</b>
+/// <code>
+/// [EventDomain]
+/// public static partial class MyEvents
+/// {
+///     [EventArgs(typeof(MyPayload))]
+///     private static readonly EventKey _OnSomething = new();
+/// }
+/// </code>
+/// The generator will emit the <c>OnSomething</c> event accessor property (for +=/Invoke) along with
+/// per-event <c>InvokeOnSomething</c> / <c>GlobalInvokeOnSomething</c> convenience methods.
+/// Full subscription with priority, tags, etc. is done via <c>OnSomething.Subscribe(...)</c>.
+/// </para>
+/// </summary>
+public readonly struct EventKey;
+
+}

--- a/Prowl.Runtime/Events/EventManager.WaitFor.cs
+++ b/Prowl.Runtime/Events/EventManager.WaitFor.cs
@@ -1,0 +1,163 @@
+// This file is part of the Prowl Game Engine
+// Licensed under the MIT License. See the LICENSE file in the project root for details.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Prowl.Runtime.Events;
+
+public partial class EventManager<T> where T : struct, Enum
+{
+    /// <summary>
+    /// Returns a <see cref="Task{TArgs}"/> that completes the next time
+    /// <paramref name="eventType"/> is invoked with arguments of type
+    /// <typeparamref name="TArgs"/>. The internal subscription is removed
+    /// automatically once the task transitions to a final state.
+    /// </summary>
+    /// <param name="eventType">The event to await.</param>
+    /// <param name="cancellationToken">
+    /// Cancels the wait. When triggered, the returned task transitions to
+    /// <see cref="TaskStatus.Canceled"/> and the subscription is disposed.
+    /// </param>
+    /// <exception cref="ObjectDisposedException">This manager has been disposed.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// <typeparamref name="TArgs"/> does not match the contract declared by
+    /// <see cref="EventArgsAttribute"/>.
+    /// </exception>
+    public Task<TArgs> WaitForEventAsync<TArgs>(
+        T eventType,
+        CancellationToken cancellationToken = default,
+#if DEBUG
+        [CallerFilePath] string? sourceFile = null,
+        [CallerLineNumber] int sourceLine = 0,
+        [CallerMemberName] string? sourceMember = null
+#else
+        string? sourceFile = null,
+        int sourceLine = 0,
+        string? sourceMember = null
+#endif
+    )
+    {
+        return WaitForEventAsync<TArgs>(eventType, predicate: null, cancellationToken, sourceFile, sourceLine, sourceMember);
+    }
+
+    /// <summary>
+    /// Returns a <see cref="Task{TArgs}"/> that completes the next time
+    /// <paramref name="eventType"/> is invoked with arguments matching
+    /// <paramref name="predicate"/>. Invocations for which the predicate
+    /// returns <c>false</c> are ignored — the wait continues until the
+    /// predicate matches, the token is cancelled, or this manager is disposed.
+    /// </summary>
+    public Task<TArgs> WaitForEventAsync<TArgs>(
+        T eventType,
+        Func<TArgs, bool>? predicate,
+        CancellationToken cancellationToken = default,
+#if DEBUG
+        [CallerFilePath] string? sourceFile = null,
+        [CallerLineNumber] int sourceLine = 0,
+        [CallerMemberName] string? sourceMember = null
+#else
+        string? sourceFile = null,
+        int sourceLine = 0,
+        string? sourceMember = null
+#endif
+    )
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (!EventArgsContract<T>.IsValid<TArgs>(eventType))
+        {
+            throw new InvalidOperationException(
+                $"[EventSystem] Type mismatch on {typeof(T).Name}.{eventType}: " +
+                $"WaitForEventAsync invoked with '{typeof(TArgs).Name}' but the event " +
+                $"declares '{EventArgsContract<T>.GetDeclaredName(eventType)}' via [EventArgs].");
+        }
+
+        if (cancellationToken.IsCancellationRequested)
+            return Task.FromCanceled<TArgs>(cancellationToken);
+
+        TaskCompletionSource<TArgs> tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        WaitState<TArgs> state = new(tcs, predicate);
+
+        EventDelegateContainer<T, TArgs> container = new(
+            eventType, state.Handle, default, sourceFile, sourceLine, sourceMember);
+        state.Subscription = container;
+        AddDelegate(container);
+
+        if (cancellationToken.CanBeCanceled)
+        {
+            state.Registration = cancellationToken.Register(static s =>
+            {
+                WaitState<TArgs> ws = (WaitState<TArgs>)s!;
+                ws.Cancel();
+            }, state);
+        }
+
+        return tcs.Task;
+    }
+
+    /// <summary>
+    /// Awaits the next firing of a parameterless event. Equivalent to the
+    /// generic <c>WaitForEventAsync&lt;Unit&gt;</c> overload.
+    /// </summary>
+    public async Task WaitForEventAsync(
+        T eventType,
+        CancellationToken cancellationToken = default,
+#if DEBUG
+        [CallerFilePath] string? sourceFile = null,
+        [CallerLineNumber] int sourceLine = 0,
+        [CallerMemberName] string? sourceMember = null
+#else
+        string? sourceFile = null,
+        int sourceLine = 0,
+        string? sourceMember = null
+#endif
+    )
+    {
+        await WaitForEventAsync<Unit>(eventType, cancellationToken, sourceFile, sourceLine, sourceMember).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Holds the completion source, optional predicate, subscription, and
+    /// cancellation registration for a single <see cref="WaitForEventAsync{TArgs}"/>
+    /// call. Encapsulates the cleanup logic so completion, cancellation, and
+    /// predicate paths all share the same teardown.
+    /// </summary>
+    private sealed class WaitState<TArgs>
+    {
+        private readonly TaskCompletionSource<TArgs> _tcs;
+        private readonly Func<TArgs, bool>? _predicate;
+
+        internal EventDelegateContainer<T, TArgs>? Subscription;
+        internal CancellationTokenRegistration Registration;
+
+        internal WaitState(TaskCompletionSource<TArgs> tcs, Func<TArgs, bool>? predicate)
+        {
+            _tcs = tcs;
+            _predicate = predicate;
+        }
+
+        internal void Handle(TArgs args)
+        {
+            if (_predicate is not null && !_predicate(args))
+                return;
+
+            if (_tcs.TrySetResult(args))
+                Cleanup();
+        }
+
+        internal void Cancel()
+        {
+            if (_tcs.TrySetCanceled())
+                Cleanup();
+        }
+
+        private void Cleanup()
+        {
+            Subscription?.Dispose();
+            Registration.Dispose();
+        }
+    }
+}

--- a/Prowl.Runtime/Events/EventManager.WaitFor.cs
+++ b/Prowl.Runtime/Events/EventManager.WaitFor.cs
@@ -29,7 +29,7 @@ public partial class EventManager<T> where T : struct, Enum
     public Task<TArgs> WaitForEventAsync<TArgs>(
         T eventType,
         CancellationToken cancellationToken = default,
-#if DEBUG
+#if EVENT_DEBUG
         [CallerFilePath] string? sourceFile = null,
         [CallerLineNumber] int sourceLine = 0,
         [CallerMemberName] string? sourceMember = null
@@ -54,7 +54,7 @@ public partial class EventManager<T> where T : struct, Enum
         T eventType,
         Func<TArgs, bool>? predicate,
         CancellationToken cancellationToken = default,
-#if DEBUG
+#if EVENT_DEBUG
         [CallerFilePath] string? sourceFile = null,
         [CallerLineNumber] int sourceLine = 0,
         [CallerMemberName] string? sourceMember = null
@@ -105,7 +105,7 @@ public partial class EventManager<T> where T : struct, Enum
     public async Task WaitForEventAsync(
         T eventType,
         CancellationToken cancellationToken = default,
-#if DEBUG
+#if EVENT_DEBUG
         [CallerFilePath] string? sourceFile = null,
         [CallerLineNumber] int sourceLine = 0,
         [CallerMemberName] string? sourceMember = null

--- a/Prowl.Runtime/Events/EventManager.cs
+++ b/Prowl.Runtime/Events/EventManager.cs
@@ -1,0 +1,573 @@
+// This file is part of the Prowl Game Engine
+// Licensed under the MIT License. See the LICENSE file in the project root for details.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+namespace Prowl.Runtime.Events;
+
+public partial class EventManager<T> : IDisposable where T : struct, Enum
+{
+    private static readonly List<EventManager<T>> s_instances = new List<EventManager<T>>();
+    private static readonly object s_instancesLock = new();
+    private bool _disposed;
+
+    /// <summary>
+    /// Copy-on-write snapshot of the static instances list, rebuilt only on Add/Remove.
+    /// </summary>
+    private static EventManager<T>[] s_instancesSnapshot = [];
+
+    /// <summary>
+    /// Copy-on-write snapshot containing only global managers.
+    /// Rebuilt when instances or their <see cref="Global"/> flag change.
+    /// </summary>
+    private static EventManager<T>[] s_globalSnapshot = [];
+
+    /// <summary>
+    /// Rebuilds the global-only snapshot from the current instances list.
+    /// Must be called under <see cref="s_instancesLock"/>.
+    /// </summary>
+    private static void RebuildGlobalSnapshot()
+    {
+        List<EventManager<T>> globals = new List<EventManager<T>>();
+        for (int i = 0; i < s_instances.Count; i++)
+        {
+            if (s_instances[i].Global)
+                globals.Add(s_instances[i]);
+        }
+        s_globalSnapshot = globals.Count > 0 ? [.. globals] : [];
+    }
+
+    public static EventManager<T> LastGlobalInstance
+    {
+        get
+        {
+            EventManager<T>[] snapshot = s_globalSnapshot;
+            for (int i = snapshot.Length - 1; i >= 0; i--)
+            {
+                if (snapshot[i].Enabled)
+                    return snapshot[i];
+            }
+            return null;
+        }
+    }
+
+    private readonly ConcurrentDictionary<T, Event<T>> _events = new ConcurrentDictionary<T, Event<T>>();
+    private int _batchDepth;
+
+    private bool global = false;
+    public bool Global
+    {
+        get => global;
+        set
+        {
+            if (global == value) return;
+            global = value;
+            lock (s_instancesLock)
+            {
+                RebuildGlobalSnapshot();
+            }
+        }
+    }
+
+    private bool enabled = true;
+    public bool Enabled
+    {
+        get => enabled;
+        set
+        {
+            enabled = value;
+            foreach (Event<T> xEvent in _events.Values)
+            {
+                xEvent.Enabled = value;
+            }
+        }
+    }
+
+    public EventManager(bool global = false)
+    {
+        Global = global;
+        lock (s_instancesLock)
+        {
+            s_instances.Add(this);
+            s_instancesSnapshot = [.. s_instances];
+            RebuildGlobalSnapshot();
+        }
+    }
+
+    /// <summary>
+    /// Returns the <see cref="Event{T}"/> for the given enum value,
+    /// creating it atomically on first access via <see cref="ConcurrentDictionary{TKey,TValue}.GetOrAdd(TKey, Func{TKey,TValue})"/>.
+    /// </summary>
+    private Event<T> GetOrCreateEvent(T eventType)
+    {
+        return _events.GetOrAdd(eventType, key =>
+        {
+            Event<T> evt = new Event<T>(this, key);
+            if (!enabled)
+                evt.Enabled = false;
+            int depth = _batchDepth;
+            for (int i = 0; i < depth; i++)
+                evt.BeginBatch();
+            return evt;
+        });
+    }
+
+    public bool AddDelegate(EventDelegateContainer<T> eventDelegate, bool allowMultiple = false)
+    {
+        return GetOrCreateEvent(eventDelegate.EventType).Add(eventDelegate, allowMultiple);
+    }
+
+    public void RemoveDelegate(EventDelegateContainer<T> eventDelegate)
+    {
+        if (_events.TryGetValue(eventDelegate.EventType, out Event<T>? evt))
+        {
+            evt.Remove(eventDelegate);
+        }
+    }
+
+    /// <summary>
+    /// Removes the first delegate container that wraps the given handler delegate.
+    /// Used by the generated event <c>-=</c> accessors.
+    /// </summary>
+    public bool RemoveDelegate(T eventType, Delegate handler)
+    {
+        if (_events.TryGetValue(eventType, out Event<T>? evt))
+            return evt.RemoveByDelegate(handler);
+        return false;
+    }
+
+    /// <summary>
+    /// Begins a batch operation on all existing events. While batched,
+    /// <see cref="Event{T}.Add"/> and <see cref="Event{T}.Remove"/> will not
+    /// rebuild COW snapshots. Call <see cref="EndBatch"/> when finished.
+    /// Calls may be nested.
+    /// </summary>
+    public void BeginBatch()
+    {
+        _batchDepth++;
+        foreach (Event<T> evt in _events.Values)
+            evt.BeginBatch();
+    }
+
+    /// <summary>
+    /// Ends a batch operation. If this is the outermost batch and mutations
+    /// occurred, COW snapshots are rebuilt once per event.
+    /// </summary>
+    public void EndBatch()
+    {
+        if (_batchDepth > 0)
+            _batchDepth--;
+        foreach (Event<T> evt in _events.Values)
+            evt.EndBatch();
+    }
+
+
+
+    public void RemoveEvent(Event<T> xEvent)
+    {
+        _events.Remove(xEvent.EventType, out _);
+    }
+
+    public void EnableEvent(T eventType)
+    {
+        GetOrCreateEvent(eventType).Enabled = true;
+    }
+
+    public void DisableEvent(T eventType)
+    {
+        GetOrCreateEvent(eventType).Enabled = false;
+    }
+
+    public void EnableByTag(string tag)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        foreach (var evt in _events.Values)
+            evt.EnableByTag(tag);
+    }
+
+    public void DisableByTag(string tag)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        foreach (var evt in _events.Values)
+            evt.DisableByTag(tag);
+    }
+
+    public void RemoveByTag(string tag)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        foreach (var evt in _events.Values)
+            evt.RemoveByTag(tag);
+    }
+
+
+    /// <summary>
+    /// Invoke an event with typed arguments. Only delegates registered
+    /// with a matching <typeparamref name="TArgs"/> will be called.
+    /// </summary>
+    public void InvokeEvent<TArgs>(T eventType, TArgs args)
+    {
+        if (_disposed || !Enabled) return;
+
+        if (!EventArgsContract<T>.IsValid<TArgs>(eventType))
+        {
+            EventSystemDiagnostics.LogError?.Invoke(
+                $"[EventSystem] Type mismatch on {typeof(T).Name}.{eventType}: " +
+                $"invoked with '{typeof(TArgs).Name}' but the event declares " +
+                $"'{EventArgsContract<T>.GetDeclaredName(eventType)}' via [EventArgs].");
+            return;
+        }
+
+        if (_events.TryGetValue(eventType, out Event<T>? evt))
+            evt.Invoke(args);
+    }
+
+    /// <summary>
+    /// Returns the <see cref="Event{T}"/> for the given enum value if it
+    /// has been created, or <c>null</c> if no subscribers have been registered.
+    /// </summary>
+    public Event<T>? GetEvent(T eventType)
+    {
+        _events.TryGetValue(eventType, out Event<T>? evt);
+        return evt;
+    }
+
+    /// <summary>
+    /// Invoke a parameterless event.
+    /// </summary>
+    public void InvokeEvent(T eventType)
+    {
+        InvokeEvent(eventType, default(Unit));
+    }
+
+    /// <summary>
+    /// Asynchronously invoke an event with typed arguments. Async handlers are
+    /// awaited sequentially; synchronous handlers are called inline.
+    /// Intended for editor/tool events that perform I/O.
+    /// </summary>
+    public async Task InvokeEventAsync<TArgs>(T eventType, TArgs args)
+    {
+        if (_disposed || !Enabled) return;
+
+        if (!EventArgsContract<T>.IsValid<TArgs>(eventType))
+        {
+            EventSystemDiagnostics.LogError?.Invoke(
+                $"[EventSystem] Type mismatch on {typeof(T).Name}.{eventType}: " +
+                $"invoked with '{typeof(TArgs).Name}' but the event declares " +
+                $"'{EventArgsContract<T>.GetDeclaredName(eventType)}' " +
+                $"via [EventArgs].");
+            return;
+        }
+
+        if (_events.TryGetValue(eventType, out Event<T>? evt))
+            await evt.InvokeAsync(args).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Asynchronously invoke a parameterless event.
+    /// </summary>
+    public Task InvokeEventAsync(T eventType)
+    {
+        return InvokeEventAsync(eventType, default(Unit));
+    }
+
+    /// <summary>
+    /// Register a typed delegate for an event.
+    /// </summary>
+    public EventDelegateContainer<T, TArgs> AddNewDelegate<TArgs>(
+        T eventType, Action<TArgs> eventDelegate, ExecutionOrder priority = default,
+#if DEBUG
+        [CallerFilePath] string? sourceFile = null,
+        [CallerLineNumber] int sourceLine = 0,
+        [CallerMemberName] string? sourceMember = null,
+#else
+        string? sourceFile = null,
+        int sourceLine = 0,
+        string? sourceMember = null,
+#endif
+        bool allowMultiple = false,
+        string[]? tags = null
+    )
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (!EventArgsContract<T>.IsValid<TArgs>(eventType))
+        {
+            throw new InvalidOperationException(
+                $"[EventSystem] Type mismatch on {typeof(T).Name}.{eventType}: " +
+                $"handler registered with '{typeof(TArgs).Name}' but the event " +
+                $"declares '{EventArgsContract<T>.GetDeclaredName(eventType)}' " +
+                $"via [EventArgs]. Fix the subscriber's type parameter.");
+        }
+        EventDelegateContainer<T, TArgs> container = new(eventType, eventDelegate, priority, sourceFile, sourceLine, sourceMember, tags);
+        GetOrCreateEvent(eventType).Add(container, allowMultiple);
+        return container;
+    }
+
+    /// <summary>
+    /// Register a parameterless delegate for an event.
+    /// </summary>
+    public EventDelegateContainer<T, Unit> AddNewDelegate(
+        T eventType, Action eventDelegate, ExecutionOrder priority = default,
+#if DEBUG
+        [CallerFilePath] string? sourceFile = null,
+        [CallerLineNumber] int sourceLine = 0,
+        [CallerMemberName] string? sourceMember = null
+#else
+        string? sourceFile = null,
+        int sourceLine = 0,
+        string? sourceMember = null
+#endif
+        ,bool allowMultiple = false,
+        string[]? tags = null
+    )
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (!EventArgsContract<T>.IsValid<Unit>(eventType))
+        {
+            throw new InvalidOperationException(
+                $"[EventSystem] Type mismatch on {typeof(T).Name}.{eventType}: " +
+                $"handler registered with 'Unit' (parameterless) but the event " +
+                $"declares '{EventArgsContract<T>.GetDeclaredName(eventType)}' " +
+                $"via [EventArgs]. Fix the subscriber's type parameter.");
+        }
+
+        ParameterlessEventDelegateContainer<T> container = new(eventType, eventDelegate, priority, sourceFile, sourceLine, sourceMember, tags);
+        GetOrCreateEvent(eventType).Add(container, allowMultiple);
+        return container;
+    }
+
+    /// <summary>
+    /// Register a typed delegate that is automatically disposed after a single invocation.
+    /// </summary>
+    public OneTimeEventDelegateContainer<T, TArgs> SubscribeOnce<TArgs>(
+        T eventType, Action<TArgs> eventDelegate, ExecutionOrder priority = default,
+#if DEBUG
+        [CallerFilePath] string? sourceFile = null,
+        [CallerLineNumber] int sourceLine = 0,
+        [CallerMemberName] string? sourceMember = null,
+#else
+        string? sourceFile = null,
+        int sourceLine = 0,
+        string? sourceMember = null,
+#endif
+        string[]? tags = null
+    )
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (!EventArgsContract<T>.IsValid<TArgs>(eventType))
+        {
+            throw new InvalidOperationException(
+                $"[EventSystem] Type mismatch on {typeof(T).Name}.{eventType}: " +
+                $"handler registered with '{typeof(TArgs).Name}' but the event " +
+                $"declares '{EventArgsContract<T>.GetDeclaredName(eventType)}' " +
+                $"via [EventArgs]. Fix the subscriber's type parameter.");
+        }
+        OneTimeEventDelegateContainer<T, TArgs> container = new(eventType, eventDelegate, priority, sourceFile, sourceLine, sourceMember, tags);
+        GetOrCreateEvent(eventType).Add(container);
+        return container;
+    }
+
+    /// <summary>
+    /// Register a parameterless delegate that is automatically disposed after a single invocation.
+    /// </summary>
+    public OneTimeParameterlessEventDelegateContainer<T> SubscribeOnce(
+        T eventType, Action eventDelegate, ExecutionOrder priority = default,
+#if DEBUG
+        [CallerFilePath] string? sourceFile = null,
+        [CallerLineNumber] int sourceLine = 0,
+        [CallerMemberName] string? sourceMember = null,
+#else
+        string? sourceFile = null,
+        int sourceLine = 0,
+        string? sourceMember = null,
+#endif
+        string[]? tags = null
+    )
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (!EventArgsContract<T>.IsValid<Unit>(eventType))
+        {
+            throw new InvalidOperationException(
+                $"[EventSystem] Type mismatch on {typeof(T).Name}.{eventType}: " +
+                $"handler registered with 'Unit' (parameterless) but the event " +
+                $"declares '{EventArgsContract<T>.GetDeclaredName(eventType)}' " +
+                $"via [EventArgs]. Fix the subscriber's type parameter.");
+        }
+
+        OneTimeParameterlessEventDelegateContainer<T> container = new(eventType, eventDelegate, priority, sourceFile, sourceLine, sourceMember, tags);
+        GetOrCreateEvent(eventType).Add(container);
+        return container;
+    }
+
+
+    /// <summary>
+    /// Register a typed async delegate for an event.
+    /// </summary>
+    public AsyncEventDelegateContainer<T, TArgs> AddNewAsyncDelegate<TArgs>(
+        T eventType, Func<TArgs, Task> eventDelegate, ExecutionOrder priority = default,
+#if DEBUG
+        [CallerFilePath] string? sourceFile = null,
+        [CallerLineNumber] int sourceLine = 0,
+        [CallerMemberName] string? sourceMember = null
+#else
+        string? sourceFile = null,
+        int sourceLine = 0,
+        string? sourceMember = null
+#endif
+        , bool allowMultiple = false,
+        string[]? tags = null
+    )
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (!EventArgsContract<T>.IsValid<TArgs>(eventType))
+        {
+            throw new InvalidOperationException(
+                $"[EventSystem] Type mismatch on {typeof(T).Name}.{eventType}: " +
+                $"async handler registered with '{typeof(TArgs).Name}' but the event " +
+                $"declares '{EventArgsContract<T>.GetDeclaredName(eventType)}' " +
+                $"via [EventArgs]. Fix the subscriber's type parameter.");
+        }
+        AsyncEventDelegateContainer<T, TArgs> container = new(eventType, eventDelegate, priority, sourceFile, sourceLine, sourceMember, tags);
+        GetOrCreateEvent(eventType).Add(container, allowMultiple);
+        return container;
+    }
+
+    /// <summary>
+    /// Register a parameterless async delegate for an event.
+    /// </summary>
+    public AsyncEventDelegateContainer<T, Unit> AddNewAsyncDelegate(
+        T eventType, Func<Task> eventDelegate, ExecutionOrder priority = default,
+#if DEBUG
+        [CallerFilePath] string? sourceFile = null,
+        [CallerLineNumber] int sourceLine = 0,
+        [CallerMemberName] string? sourceMember = null
+#else
+        string? sourceFile = null,
+        int sourceLine = 0,
+        string? sourceMember = null
+#endif
+        , bool allowMultiple = false,
+        string[]? tags = null
+    )
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (!EventArgsContract<T>.IsValid<Unit>(eventType))
+        {
+            throw new InvalidOperationException(
+                $"[EventSystem] Type mismatch on {typeof(T).Name}.{eventType}: " +
+                $"async handler registered with 'Unit' (parameterless) but the event " +
+                $"declares '{EventArgsContract<T>.GetDeclaredName(eventType)}' " +
+                $"via [EventArgs]. Fix the subscriber's type parameter.");
+        }
+
+        ParameterlessAsyncEventDelegateContainer<T> container = new(eventType, eventDelegate, priority, sourceFile, sourceLine, sourceMember, tags);
+        GetOrCreateEvent(eventType).Add(container, allowMultiple);
+        return container;
+    }
+
+
+    /// <summary>
+    /// Invoke an event with typed arguments across all global managers.
+    /// </summary>
+    public static void GlobalInvokeEvent<TArgs>(T eventType, TArgs args)
+    {
+        EventManager<T>[] snapshot = s_globalSnapshot;
+
+        for (int i = 0; i < snapshot.Length; i++)
+        {
+            EventManager<T> instance = snapshot[i];
+            if (instance.Enabled)
+            {
+                instance.InvokeEvent(eventType, args);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Invoke a parameterless event across all global managers.
+    /// </summary>
+    public static void GlobalInvokeEvent(T eventType)
+    {
+        GlobalInvokeEvent(eventType, default(Unit));
+    }
+
+    public static void GlobalEnableByTag(string tag)
+    {
+        EventManager<T>[] snapshot = s_instancesSnapshot;
+        for (int i = 0; i < snapshot.Length; i++)
+            snapshot[i].EnableByTag(tag);
+    }
+
+    public static void GlobalDisableByTag(string tag)
+    {
+        EventManager<T>[] snapshot = s_instancesSnapshot;
+        for (int i = 0; i < snapshot.Length; i++)
+            snapshot[i].DisableByTag(tag);
+    }
+
+    public static void GlobalRemoveByTag(string tag)
+    {
+        EventManager<T>[] snapshot = s_instancesSnapshot;
+        for (int i = 0; i < snapshot.Length; i++)
+            snapshot[i].RemoveByTag(tag);
+    }
+
+    /// <summary>
+    /// Asynchronously invoke an event with typed arguments across all global managers.
+    /// </summary>
+    public static async Task GlobalInvokeEventAsync<TArgs>(T eventType, TArgs args)
+    {
+        EventManager<T>[] snapshot = s_globalSnapshot;
+
+        for (int i = 0; i < snapshot.Length; i++)
+        {
+            EventManager<T> instance = snapshot[i];
+            if (instance.Enabled)
+            {
+                await instance.InvokeEventAsync(eventType, args).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Asynchronously invoke a parameterless event across all global managers.
+    /// </summary>
+    public static Task GlobalInvokeEventAsync(T eventType)
+    {
+        return GlobalInvokeEventAsync(eventType, default(Unit));
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        enabled = false;
+        foreach (Event<T> evt in _events.Values)
+            evt.Enabled = false;
+        _events.Clear();
+        lock (s_instancesLock)
+        {
+            s_instances.Remove(this);
+            s_instancesSnapshot = [.. s_instances];
+            RebuildGlobalSnapshot();
+        }
+        GC.SuppressFinalize(this);
+    }
+
+    ~EventManager()
+    {
+        if (!_disposed)
+        {
+            EventSystemDiagnostics.LogWarning?.Invoke($"EventManager<{typeof(T).Name}> was not disposed before finalization.");
+        }
+    }
+}

--- a/Prowl.Runtime/Events/EventManager.cs
+++ b/Prowl.Runtime/Events/EventManager.cs
@@ -279,7 +279,7 @@ public partial class EventManager<T> : IDisposable where T : struct, Enum
     /// </summary>
     public EventDelegateContainer<T, TArgs> AddNewDelegate<TArgs>(
         T eventType, Action<TArgs> eventDelegate, ExecutionOrder priority = default,
-#if DEBUG
+#if EVENT_DEBUG
         [CallerFilePath] string? sourceFile = null,
         [CallerLineNumber] int sourceLine = 0,
         [CallerMemberName] string? sourceMember = null,
@@ -312,7 +312,7 @@ public partial class EventManager<T> : IDisposable where T : struct, Enum
     /// </summary>
     public EventDelegateContainer<T, Unit> AddNewDelegate(
         T eventType, Action eventDelegate, ExecutionOrder priority = default,
-#if DEBUG
+#if EVENT_DEBUG
         [CallerFilePath] string? sourceFile = null,
         [CallerLineNumber] int sourceLine = 0,
         [CallerMemberName] string? sourceMember = null
@@ -346,7 +346,7 @@ public partial class EventManager<T> : IDisposable where T : struct, Enum
     /// </summary>
     public OneTimeEventDelegateContainer<T, TArgs> SubscribeOnce<TArgs>(
         T eventType, Action<TArgs> eventDelegate, ExecutionOrder priority = default,
-#if DEBUG
+#if EVENT_DEBUG
         [CallerFilePath] string? sourceFile = null,
         [CallerLineNumber] int sourceLine = 0,
         [CallerMemberName] string? sourceMember = null,
@@ -378,7 +378,7 @@ public partial class EventManager<T> : IDisposable where T : struct, Enum
     /// </summary>
     public OneTimeParameterlessEventDelegateContainer<T> SubscribeOnce(
         T eventType, Action eventDelegate, ExecutionOrder priority = default,
-#if DEBUG
+#if EVENT_DEBUG
         [CallerFilePath] string? sourceFile = null,
         [CallerLineNumber] int sourceLine = 0,
         [CallerMemberName] string? sourceMember = null,
@@ -412,7 +412,7 @@ public partial class EventManager<T> : IDisposable where T : struct, Enum
     /// </summary>
     public AsyncEventDelegateContainer<T, TArgs> AddNewAsyncDelegate<TArgs>(
         T eventType, Func<TArgs, Task> eventDelegate, ExecutionOrder priority = default,
-#if DEBUG
+#if EVENT_DEBUG
         [CallerFilePath] string? sourceFile = null,
         [CallerLineNumber] int sourceLine = 0,
         [CallerMemberName] string? sourceMember = null
@@ -445,7 +445,7 @@ public partial class EventManager<T> : IDisposable where T : struct, Enum
     /// </summary>
     public AsyncEventDelegateContainer<T, Unit> AddNewAsyncDelegate(
         T eventType, Func<Task> eventDelegate, ExecutionOrder priority = default,
-#if DEBUG
+#if EVENT_DEBUG
         [CallerFilePath] string? sourceFile = null,
         [CallerLineNumber] int sourceLine = 0,
         [CallerMemberName] string? sourceMember = null

--- a/Prowl.Runtime/Events/EventParam.cs
+++ b/Prowl.Runtime/Events/EventParam.cs
@@ -1,0 +1,11 @@
+// This file is part of the Prowl Game Engine
+// Licensed under the MIT License. See the LICENSE file in the project root for details.
+
+namespace Prowl.Runtime.Events {
+
+/// <summary>
+/// A zero-size struct used as <c>TArgs</c> for parameterless events.
+/// </summary>
+public readonly struct Unit;
+
+}

--- a/Prowl.Runtime/Events/EventSystemDiagnostics.cs
+++ b/Prowl.Runtime/Events/EventSystemDiagnostics.cs
@@ -1,0 +1,28 @@
+// This file is part of the Prowl Game Engine
+// Licensed under the MIT License. See the LICENSE file in the project root for details.
+
+using System;
+
+namespace Prowl.Runtime.Events {
+
+/// <summary>
+/// Configurable logging hooks for the event system.
+/// The hosting application should assign
+/// <see cref="LogWarning"/> and <see cref="LogError"/> during startup
+/// so that diagnostic messages are routed through the engine's logging
+/// infrastructure.
+/// </summary>
+public static class EventSystemDiagnostics
+{
+    /// <summary>
+    /// Called for non-critical diagnostic messages (e.g. slow handlers, sync-over-async).
+    /// </summary>
+    public static Action<string>? LogWarning { get; set; }
+
+    /// <summary>
+    /// Called for error-level diagnostic messages (e.g. type-mismatch on invoke).
+    /// </summary>
+    public static Action<string>? LogError { get; set; }
+}
+
+}

--- a/Prowl.Runtime/Events/ExecutionOrder.cs
+++ b/Prowl.Runtime/Events/ExecutionOrder.cs
@@ -1,0 +1,132 @@
+// This file is part of the Prowl Game Engine
+// Licensed under the MIT License. See the LICENSE file in the project root for details.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Prowl.Runtime.Events;
+
+/// <summary>
+/// Represents a hierarchical execution order as an ordered array of integers.
+/// Used to stably order event delivery (Update, FixedUpdate, etc.) according to
+/// scene hierarchy depth and sibling index.
+/// Comparison is lexicographic: <c>[0,34,5]</c> &lt; <c>[1,0,2]</c> &lt; <c>[1,0,4]</c>.
+/// A <c>default</c> instance is equivalent to <c>[0]</c>.
+/// </summary>
+public readonly struct ExecutionOrder : IComparable<ExecutionOrder>, IEquatable<ExecutionOrder>
+{
+    private static readonly int[] s_default = [0];
+
+    private readonly int[]? _levels;
+
+    /// <summary>The order levels (path in the hierarchy). Never null; defaults to a single-element <c>[0]</c>.</summary>
+    public ReadOnlySpan<int> Levels => _levels ?? s_default;
+
+    public ExecutionOrder(params int[] levels)
+    {
+        _levels = levels is { Length: > 0 } ? levels : null;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int CompareTo(ExecutionOrder other)
+    {
+        int[]  a = _levels ?? s_default;
+        int[]  b = other._levels ?? s_default;
+        if (ReferenceEquals(a, b)) return 0;
+        return CompareLevels(a, b);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int CompareLevels(int[] a, int[] b)
+    {
+        int len = Math.Min(a.Length, b.Length);
+        for (int i = 0; i < len; i++)
+        {
+            int d = a[i] - b[i];
+            if (d != 0) return d;
+        }
+        return a.Length - b.Length;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool Equals(ExecutionOrder other)
+    {
+        int[] a = _levels ?? s_default;
+        int[] b = other._levels ?? s_default;
+        if (ReferenceEquals(a, b)) return true;
+        return a.AsSpan().SequenceEqual(b);
+    }
+
+    public override bool Equals(object? obj) => obj is ExecutionOrder other && Equals(other);
+
+    public override int GetHashCode()
+    {
+        int[] levels = _levels ?? s_default;
+        HashCode hc = new();
+        for (int i = 0; i < levels.Length; i++)
+            hc.Add(levels[i]);
+        return hc.ToHashCode();
+    }
+
+    public static bool operator ==(ExecutionOrder left, ExecutionOrder right) => left.Equals(right);
+    public static bool operator !=(ExecutionOrder left, ExecutionOrder right) => !left.Equals(right);
+    public static bool operator <(ExecutionOrder left, ExecutionOrder right) => left.CompareTo(right) < 0;
+    public static bool operator >(ExecutionOrder left, ExecutionOrder right) => left.CompareTo(right) > 0;
+    public static bool operator <=(ExecutionOrder left, ExecutionOrder right) => left.CompareTo(right) <= 0;
+    public static bool operator >=(ExecutionOrder left, ExecutionOrder right) => left.CompareTo(right) >= 0;
+
+    /// <summary>Allows <c>int</c> to be used where <see cref="ExecutionOrder"/> is expected.</summary>
+    public static implicit operator ExecutionOrder(int single) => new(single);
+
+    /// <summary>Allows <c>int[]</c> to be used where <see cref="ExecutionOrder"/> is expected.</summary>
+    public static implicit operator ExecutionOrder(int[] levels) => new(levels);
+
+    public override string ToString()
+    {
+        int[] levels = _levels ?? s_default;
+        if (levels.Length == 1) return levels[0].ToString();
+        return "[" + string.Join(",", levels) + "]";
+    }
+
+    /// <summary>
+    /// Sorts a <see cref="List{ExecutionOrder}"/> in-place using an insertion sort
+    /// optimized for the small lists typical in event systems. Avoids repeated
+    /// <see cref="ReadOnlySpan{T}"/> construction by working directly with the
+    /// underlying <c>int[]</c> arrays and uses binary search on the already-sorted
+    /// prefix to find the insertion point, reducing the number of comparisons from
+    /// O(n²) to O(n log n) while keeping O(n²) moves (which dominate only at
+    /// larger sizes where the list would be unusual for an event system).
+    /// </summary>
+    public static void Sort(List<ExecutionOrder> list)
+    {
+        Span<ExecutionOrder> span = CollectionsMarshal.AsSpan(list);
+        int count = span.Length;
+        if (count <= 1) return;
+
+        for (int i = 1; i < count; i++)
+        {
+            ExecutionOrder key = span[i];
+            int[] keyLevels = key._levels ?? s_default;
+
+            // Binary search in the sorted region [0..i)
+            int lo = 0, hi = i;
+            while (lo < hi)
+            {
+                int mid = (lo + hi) >>> 1;
+                if (CompareLevels(span[mid]._levels ?? s_default, keyLevels) <= 0)
+                    lo = mid + 1;
+                else
+                    hi = mid;
+            }
+
+            // Shift elements [lo..i) right by one
+            if (lo < i)
+            {
+                span.Slice(lo, i - lo).CopyTo(span.Slice(lo + 1));
+                span[lo] = key;
+            }
+        }
+    }
+}

--- a/Prowl.Runtime/Events/GameEvents.cs
+++ b/Prowl.Runtime/Events/GameEvents.cs
@@ -1,0 +1,39 @@
+﻿// This file is part of the Prowl Game Engine
+// Licensed under the MIT License. See the LICENSE file in the project root for details.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Prowl.Runtime.Resources;
+
+namespace Prowl.Runtime.Events;
+
+[EventDomain]
+public partial class GameEvents
+{
+    [EventArgs(typeof(GameEventsArgs))]
+    private static readonly EventKey _OnBeforeBeginUpdate = new();
+    [EventArgs(typeof(GameEventsArgs))]
+    private static readonly EventKey _OnAfterBeginUpdate = new();
+
+    [EventArgs(typeof(GameEventsArgs))]
+    private static readonly EventKey _OnBeforeFixedUpdate = new();
+    [EventArgs(typeof(GameEventsArgs))]
+    private static readonly EventKey _OnAfterFixedUpdate = new();
+
+    [EventArgs(typeof(GameEventsArgs))]
+    private static readonly EventKey _OnBeforeUpdate = new();
+    private static readonly EventKey _OnUpdate = new();
+    [EventArgs(typeof(GameEventsArgs))]
+    private static readonly EventKey _OnAfterUpdate = new();
+
+    [EventArgs(typeof(GameEventsArgs))]
+    private static readonly EventKey _OnBeforeEndUpdate = new();
+    [EventArgs(typeof(GameEventsArgs))]
+    private static readonly EventKey _OnAfterEndUpdate = new();
+
+    public readonly record struct GameEventsArgs(Scene? Scene);
+}

--- a/Prowl.Runtime/Events/IAsyncInvocable.cs
+++ b/Prowl.Runtime/Events/IAsyncInvocable.cs
@@ -1,0 +1,19 @@
+// This file is part of the Prowl Game Engine
+// Licensed under the MIT License. See the LICENSE file in the project root for details.
+
+using System.Threading.Tasks;
+
+namespace Prowl.Runtime.Events {
+
+/// <summary>
+/// Interface for typed, async invocation of an event handler.
+/// Implemented by <see cref="AsyncEventDelegateContainer{T, TArgs}"/> so that
+/// <see cref="Event{T}.InvokeAsync{TArgs}"/> can await async handlers while still
+/// calling synchronous handlers inline.
+/// </summary>
+public interface IAsyncInvocable<in TArgs>
+{
+    Task InvokeAsync(TArgs args);
+}
+
+}

--- a/Prowl.Runtime/Events/ICancellable.cs
+++ b/Prowl.Runtime/Events/ICancellable.cs
@@ -1,0 +1,16 @@
+// This file is part of the Prowl Game Engine
+// Licensed under the MIT License. See the LICENSE file in the project root for details.
+
+namespace Prowl.Runtime.Events {
+
+/// <summary>
+/// Implement on event argument types to allow handlers to stop further propagation.
+/// When a handler sets <see cref="Cancelled"/> to <c>true</c>, subsequent handlers
+/// in the priority chain are skipped.
+/// </summary>
+public interface ICancellable
+{
+    bool Cancelled { get; set; }
+}
+
+}

--- a/Prowl.Runtime/Events/IEventDelegateContainer.cs
+++ b/Prowl.Runtime/Events/IEventDelegateContainer.cs
@@ -1,0 +1,22 @@
+// This file is part of the Prowl Game Engine
+// Licensed under the MIT License. See the LICENSE file in the project root for details.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Prowl.Runtime.Events {
+
+public interface IEventDelegateContainer : IDisposable
+{
+    public bool Enabled { get; }
+    public void Enable();
+    public void Disable();
+
+    public bool Added { get; }
+    public bool HasTag(string tag);
+}
+
+}

--- a/Prowl.Runtime/Events/IEventManagerHolder.cs
+++ b/Prowl.Runtime/Events/IEventManagerHolder.cs
@@ -1,0 +1,51 @@
+// This file is part of the Prowl Game Engine
+// Licensed under the MIT License. See the LICENSE file in the project root for details.
+
+using System;
+using System.Collections.Generic;
+
+namespace Prowl.Runtime.Events {
+
+public interface IEventManagerHolder<T> where T : struct, Enum
+{
+    EventManager<T> EventManager { get; }
+}
+
+public static class EventManagerExtensions
+{
+    public static void InvokeEvents<T, TArgs>(this IEventManagerHolder<T>[] holders, T eventType, TArgs args) where T : struct, Enum
+    {
+        for (int i = 0; i < holders.Length; i++)
+        {
+            IEventManagerHolder<T>? holder = holders[i];
+            holder?.EventManager.InvokeEvent(eventType, args);
+        }
+    }
+    public static void InvokeEvents<T, TArgs>(this List<IEventManagerHolder<T>> holders, T eventType, TArgs args) where T : struct, Enum
+    {
+        for (int i = 0; i < holders.Count; i++)
+        {
+            IEventManagerHolder<T> holder = holders[i];
+            holder?.EventManager.InvokeEvent(eventType, args);
+        }
+    }
+
+    public static void InvokeEvents<T>(this IEventManagerHolder<T>[] holders, T eventType) where T : struct, Enum
+    {
+        for (int i = 0; i < holders.Length; i++)
+        {
+            IEventManagerHolder<T>? holder = holders[i];
+            holder?.EventManager.InvokeEvent(eventType);
+        }
+    }
+    public static void InvokeEvents<T>(this List<IEventManagerHolder<T>> holders, T eventType) where T : struct, Enum
+    {
+        for (int i = 0; i < holders.Count; i++)
+        {
+            IEventManagerHolder<T> holder = holders[i];
+            holder?.EventManager.InvokeEvent(eventType);
+        }
+    }
+}
+
+}

--- a/Prowl.Runtime/Events/IInvocable.cs
+++ b/Prowl.Runtime/Events/IInvocable.cs
@@ -1,0 +1,16 @@
+// This file is part of the Prowl Game Engine
+// Licensed under the MIT License. See the LICENSE file in the project root for details.
+
+namespace Prowl.Runtime.Events {
+
+/// <summary>
+/// Interface for typed, zero-cast invocation of an event handler.
+/// Implemented by <see cref="EventDelegateContainer{T, TArgs}"/> so that
+/// callers holding a typed reference can invoke without a runtime type check.
+/// </summary>
+public interface IInvocable<in TArgs>
+{
+    void Invoke(TArgs args);
+}
+
+}

--- a/Prowl.Runtime/Events/SceneEvents.cs
+++ b/Prowl.Runtime/Events/SceneEvents.cs
@@ -1,0 +1,35 @@
+﻿// This file is part of the Prowl Game Engine
+// Licensed under the MIT License. See the LICENSE file in the project root for details.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Prowl.PaperUI;
+using Prowl.Runtime.Rendering;
+using Prowl.Runtime.Resources;
+
+using Silk.NET.Windowing;
+
+namespace Prowl.Runtime.Events;
+
+[EventDomain]
+public partial class SceneEvents
+{
+    private static readonly EventKey _FixedUpdate = new();
+    private static readonly EventKey _Update = new();
+    private static readonly EventKey _LateUpdate = new();
+    private static readonly EventKey _PreUpdate = new();
+    [EventArgs(typeof(OnRenderCollectArgs))]
+    private static readonly EventKey _OnRenderCollect = new();
+    private static readonly EventKey _DrawGizmos = new();
+    [EventArgs(typeof(Paper))]
+    private static readonly EventKey _OnGui = new();
+
+    private static readonly EventKey _OnBeforeUpdates = new();
+    private static readonly EventKey _OnFlush = new();
+
+    public readonly record struct OnRenderCollectArgs(Camera camera, List<IRenderable> renderables, List<IRenderableLight> lights);
+}

--- a/Prowl.Runtime/Events/WindowEvents.cs
+++ b/Prowl.Runtime/Events/WindowEvents.cs
@@ -1,0 +1,48 @@
+﻿// This file is part of the Prowl Game Engine
+// Licensed under the MIT License. See the LICENSE file in the project root for details.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Prowl.Runtime.Resources;
+
+using Silk.NET.Maths;
+using Silk.NET.Windowing;
+
+namespace Prowl.Runtime.Events;
+
+[EventDomain]
+public static partial class WindowEvents
+{
+    private static readonly EventKey _Load = new();
+    [EventArgs(typeof(FloatArgs))]
+    private static readonly EventKey _Update = new();
+    [EventArgs(typeof(float))]
+    private static readonly EventKey _Render = new();
+    [EventArgs(typeof(FloatArgs))]
+    private static readonly EventKey _PostRender = new();
+    [EventArgs(typeof(BoolArgs))]
+    private static readonly EventKey _FocusChanged = new();
+    [EventArgs(typeof(Vector2D<int>))]
+    private static readonly EventKey _Resize = new();
+    [EventArgs(typeof(Vector2IntArgs))]
+    private static readonly EventKey _FramebufferResize = new();
+    private static readonly EventKey _Closing = new();
+
+    [EventArgs(typeof(Vector2IntArgs))]
+    private static readonly EventKey _Move = new();
+    [EventArgs(typeof(WindowStateArgs))]
+    private static readonly EventKey _StateChanged = new();
+    [EventArgs(typeof(FileDropArgs))]
+    private static readonly EventKey _FileDrop = new();
+
+
+    public readonly record struct FloatArgs(float Value);
+    public readonly record struct BoolArgs(bool Value);
+    public readonly record struct Vector2IntArgs(Vector2D<int> Value);
+    public readonly record struct WindowStateArgs(WindowState Value);
+    public readonly record struct FileDropArgs(string[] Paths);
+}

--- a/Prowl.Runtime/Game.cs
+++ b/Prowl.Runtime/Game.cs
@@ -5,13 +5,15 @@ using System;
 
 using Echo.Logging;
 
-using Prowl.Runtime.Audio;
-
 using Prowl.PaperUI;
+using Prowl.Runtime.Audio;
+using Prowl.Runtime.Events;
 using Prowl.Runtime.GUI;
 using Prowl.Runtime.Resources;
 using Prowl.Runtime.UI;
 using Prowl.Vector;
+
+using static Prowl.Runtime.Events.GameEvents;
 
 namespace Prowl.Runtime;
 
@@ -36,6 +38,16 @@ public abstract class Game
     private int frameCounter;
 
     public Paper PaperInstance => _paper;
+
+    private GameEvents _events;
+    public GameEvents Events
+    {
+        get
+        {
+            _events ??= new GameEvents();
+            return _events;
+        }
+    }
 
     public bool DrawGizmos { get; set; }
 
@@ -63,7 +75,7 @@ public abstract class Game
 
         InitializeWindow(title, width, height);
 
-        Window.Load += () =>
+        WindowEvents.Load += () =>
         {
             AudioContext.Initialize(44100, 2, 2048);
 
@@ -82,10 +94,14 @@ public abstract class Game
             Initialize();
         };
 
-        Window.Update += (delta) =>
+        WindowEvents.Update.Subscribe((args) =>
         {
             try
             {
+                Scene? currentScene = Scene.Current;
+
+                GameEventsArgs gameEventsArgs = new(currentScene);
+
                 UpdatePaperInput();
 
                 AudioContext.Update();
@@ -94,24 +110,28 @@ public abstract class Game
                 Time.TimeStack.Clear();
                 Time.TimeStack.Push(time);
 
-                Input.UpdateActions(delta);
+                Input.UpdateActions(args.Value);
 
                 // UI input runs after low-level Input is fresh and before script Updates
                 UIEventSystem.Tick(time.Time);
 
+                Events.InvokeOnBeforeBeginUpdate(gameEventsArgs);
+
                 BeginUpdate();
 
-                Scene? currentScene = Scene.Current;
+                Events.InvokeOnAfterBeginUpdate(gameEventsArgs);
 
                 // Fixed update loop only when gameplay should run
-                fixedTimeAccumulator += delta;
+                fixedTimeAccumulator += args.Value;
                 if (Application.ShouldRunGameplay)
                 {
                     Application.IsGameplayExecuting = true;
                     int count = 0;
                     while (fixedTimeAccumulator >= Time.FixedDeltaTime && count++ < Time.MaxFixedIterations)
                     {
+                        Events.InvokeOnBeforeFixedUpdate(gameEventsArgs);
                         currentScene?.FixedUpdate();
+                        Events.InvokeOnAfterFixedUpdate(gameEventsArgs);
                         fixedTimeAccumulator -= Time.FixedDeltaTime;
                     }
                     Application.IsGameplayExecuting = false;
@@ -122,7 +142,11 @@ public abstract class Game
                     fixedTimeAccumulator = MathF.Min(fixedTimeAccumulator, Time.FixedDeltaTime);
                 }
 
+                Events.InvokeOnBeforeUpdate(gameEventsArgs);
+
                 OnUpdate(currentScene);
+
+                Events.InvokeOnAfterUpdate(gameEventsArgs);
 
                 // Consume step request re-pause after one frame
                 if (Application.StepRequested)
@@ -131,7 +155,11 @@ public abstract class Game
                     Application.IsPaused = true;
                 }
 
+                Events.InvokeOnBeforeEndUpdate(gameEventsArgs);
+
                 EndUpdate();
+
+                Events.InvokeOnAfterEndUpdate(gameEventsArgs);
 
                 if (frameCounter++ % 60 == 0)
                 { 
@@ -145,9 +173,9 @@ public abstract class Game
                 Debug.LogError(e.ToString());
                 throw;
             }
-        };
+        });
 
-        Window.Render += (delta) =>
+        WindowEvents.Render += (delta) =>
         {
             try
             {
@@ -216,18 +244,18 @@ public abstract class Game
             }
         };
 
-        Window.Resize += (size) =>
+        WindowEvents.Resize += (size) =>
         {
             // Paper's resolution is resynced from PreparePaperFrame each render frame.
             Resize(size.X, size.Y);
         };
 
-        Window.FramebufferResize += (size) =>
+        WindowEvents.FramebufferResize += (size) =>
         {
-            _paperRenderer.UpdateProjection(size.X, size.Y);
+            _paperRenderer.UpdateProjection(size.Value.X, size.Value.Y);
         };
 
-        Window.Closing += () =>
+        WindowEvents.Closing += () =>
         {
             Closing();
 

--- a/Prowl.Runtime/GameObject/GameObject.cs
+++ b/Prowl.Runtime/GameObject/GameObject.cs
@@ -120,7 +120,7 @@ public class GameObject : EngineObject, ISerializable
         internal set
         {
             _scene = new(value);
-            UpdateExecutionOrder();
+            value?.MarkExecutionOrdersDirty();
             UpdateEventDelegateState(_enabled && _enabledInHierarchy);
             ReadOnlySpan<MonoBehaviour> components = CollectionsMarshal.AsSpan(_components);
             for (int i = 0; i < components.Length; i++)
@@ -254,7 +254,7 @@ public class GameObject : EngineObject, ISerializable
     internal void SubscribeSceneEvents(Scene scene)
     {
 
-        PreUpdateDelegate = scene.Events.PreUpdate.Subscribe(PreUpdate, ExecutionOrder);
+        PreUpdateDelegate = scene.Events.PreUpdate.Subscribe(PreUpdate, ExecutionOrder, allowMultiple: true);
 
         _eventsInitialized = true;
 
@@ -401,6 +401,8 @@ public class GameObject : EngineObject, ISerializable
                 NewParent.Children.Add(this);
 
             _parent = NewParent;
+
+            Scene?.MarkExecutionOrdersDirty();
         }
 
         if (worldPositionStays)
@@ -663,8 +665,11 @@ public class GameObject : EngineObject, ISerializable
 
         SortComponents();
 
-        // Trigger OnEnable if the GameObject is in an active scene and enabled
         Scene? scene = Scene;
+        if (scene.IsValid())
+            scene.ToSubscribe.Add(newComponent);
+
+        // Trigger OnEnable if the GameObject is in an active scene and enabled
         if (scene.IsValid() && scene.IsActive && newComponent.EnabledInHierarchy)
             newComponent.InternalOnEnable();
 
@@ -705,8 +710,11 @@ public class GameObject : EngineObject, ISerializable
 
         SortComponents();
 
-        // Trigger OnEnable if the GameObject is in an active scene and enabled
         Scene? scene = Scene;
+        if (scene.IsValid())
+            scene.ToSubscribe.Add(comp);
+
+        // Trigger OnEnable if the GameObject is in an active scene and enabled
         if (scene.IsValid() && scene.IsActive && comp.EnabledInHierarchy)
             comp.InternalOnEnable();
     }
@@ -1139,7 +1147,7 @@ public class GameObject : EngineObject, ISerializable
         {
             Scene?.Flush(this);
             _disposerDelegate?.Dispose();
-        }, ExecutionOrder);
+        }, ExecutionOrder, allowMultiple: true);
 
         for (int i = Children.Count - 1; i >= 0; i--)
             Children[i].Dispose();

--- a/Prowl.Runtime/GameObject/GameObject.cs
+++ b/Prowl.Runtime/GameObject/GameObject.cs
@@ -7,9 +7,11 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 using Prowl.Echo;
 using Prowl.Runtime.Resources;
+using Prowl.Runtime.Events;
 using Prowl.Vector;
 
 namespace Prowl.Runtime;
@@ -115,7 +117,19 @@ public class GameObject : EngineObject, ISerializable
     public Scene? Scene
     {
         get => _scene != null && _scene.TryGetTarget(out Scene? scene) ? scene : null;
-        internal set => _scene = new(value);
+        internal set
+        {
+            _scene = new(value);
+            UpdateExecutionOrder();
+            UpdateEventDelegateState(_enabled && _enabledInHierarchy);
+            ReadOnlySpan<MonoBehaviour> components = CollectionsMarshal.AsSpan(_components);
+            for (int i = 0; i < components.Length; i++)
+            {
+                MonoBehaviour component = components[i];
+                // Let the component use its own effective state (its Enabled + its eih, which depends on this GO chain)
+                component.UpdateEventDelegateState(component._enabled && component._enabledInHierarchy);
+            }
+        }
     }
 
     /// <summary>Is this GameObject a prefab instance?</summary>
@@ -174,6 +188,104 @@ public class GameObject : EngineObject, ISerializable
         {
             _transform.GameObject = this; // ensure game object is this
             return _transform;
+        }
+    }
+    private bool _eventsInitialized = false;
+    private ExecutionOrder _executionOrder;
+    public ExecutionOrder ExecutionOrder
+    {
+        get
+        {
+            return _executionOrder;
+        }
+        set
+        {
+            _executionOrder = value;
+            if (_eventsInitialized && Scene.IsValid())
+            {
+                SubscribeSceneEvents(Scene);
+                DisposeSceneEvents();
+            }
+        }
+    }
+
+    public void UpdateExecutionOrder()
+    {
+        int[] goLevels;
+
+        if (_parent != null)
+        {
+            int sibIdx = _parent.Children.IndexOf(this);
+            if (sibIdx < 0) sibIdx = 0;
+            ReadOnlySpan<int> pLevels = _parent.ExecutionOrder.Levels;
+            goLevels = new int[pLevels.Length + 2];
+            pLevels.CopyTo(goLevels);
+            goLevels[pLevels.Length] = 1;
+            goLevels[pLevels.Length + 1] = sibIdx;
+        }
+        else
+        {
+            Scene? scene = Scene;
+            int sibIdx = scene != null ? scene.GetRootIndex(this) : 0;
+            if (sibIdx < 0) sibIdx = 0;
+            goLevels = [sibIdx];
+        }
+
+        ExecutionOrder = new ExecutionOrder(goLevels);
+
+        ReadOnlySpan<MonoBehaviour> components = GetComponentsAsSpan<MonoBehaviour>();
+        if (components.Length > 0)
+        {
+            int[] compLevels = new int[goLevels.Length + 2];
+            goLevels.CopyTo(compLevels, 0);
+            compLevels[goLevels.Length] = 0;
+            for (int i = 0; i < components.Length; i++)
+            {
+                compLevels[compLevels.Length - 1] = i;
+                components[i].ExecutionOrder = new ExecutionOrder((int[])compLevels.Clone());
+            }
+        }
+    }
+
+    private EventDelegateContainer<SceneEvents.EventTypes, Unit> PreUpdateDelegate = null;
+
+    private EventDelegateContainer<SceneEvents.EventTypes, Unit> _disposerDelegate;
+
+    internal void SubscribeSceneEvents(Scene scene)
+    {
+
+        PreUpdateDelegate = scene.Events.PreUpdate.Subscribe(PreUpdate, ExecutionOrder);
+
+        _eventsInitialized = true;
+
+        // Apply current effective state immediately (in case object or ancestors are disabled)
+        UpdateEventDelegateState(_enabled && _enabledInHierarchy);
+    }
+
+    internal void DisposeSceneEvents()
+    {
+        PreUpdateDelegate?.Dispose();
+        _eventsInitialized = false;
+    }
+
+
+    private void UpdateEventDelegateState(bool enable)
+    {
+        if (!_eventsInitialized)
+        {
+            Scene?.ToSubscribe.Add(this);
+            return;
+        }
+
+        if (enable)
+        {
+
+            PreUpdateDelegate?.Enable();
+
+        }
+        else
+        {
+            PreUpdateDelegate?.Disable();
         }
     }
 
@@ -686,6 +798,11 @@ public class GameObject : EngineObject, ISerializable
     /// <returns>The component of type T, or null if not found.</returns>
     public T? GetComponent<T>() where T : MonoBehaviour => (T?)GetComponent(typeof(T));
 
+    public ReadOnlySpan<T> GetComponentsAsSpan<T>() where T : MonoBehaviour
+    {
+        return CollectionsMarshal.AsSpan(GetComponentsList<T>());
+    }
+
     /// <summary>
     /// Gets the first component of the specified type attached to the GameObject.
     /// </summary>
@@ -701,6 +818,46 @@ public class GameObject : EngineObject, ISerializable
                 if (comp.GetType().IsAssignableTo(type))
                     return comp;
         return null;
+    }
+
+    public List<T> GetComponentsList<T>() where T : MonoBehaviour
+    {
+        var results = new List<T>();
+
+        var type = typeof(T);
+
+        if (type == typeof(MonoBehaviour))
+        {
+            ReadOnlySpan<MonoBehaviour> compsSpan = CollectionsMarshal.AsSpan(_components);
+
+            for (int i = 0; i < compsSpan.Length; i++)
+            {
+                var comp = compsSpan[i];
+                if (comp is T t)
+                    results.Add(t);
+            }
+
+        }
+        else if (_componentCache.TryGetValue(type, out IReadOnlyCollection<MonoBehaviour>? cached))
+        {
+            if (cached is IList<MonoBehaviour> list)
+            {
+                for (int i = 0; i < cached.Count; i++)
+                {
+                    if (list[i] is T t)
+                        results.Add(t);
+                }
+            }
+
+        }
+        else
+        {
+            foreach (MonoBehaviour comp in _components)
+                if (comp is T t)
+                    results.Add(t);
+        }
+
+        return results;
     }
 
     /// <summary>
@@ -976,6 +1133,14 @@ public class GameObject : EngineObject, ISerializable
     /// </summary>
     public override void OnDispose()
     {
+        DisposeSceneEvents();
+
+        _disposerDelegate = Scene?.Events.OnFlush.Subscribe(() =>
+        {
+            Scene?.Flush(this);
+            _disposerDelegate?.Dispose();
+        }, ExecutionOrder);
+
         for (int i = Children.Count - 1; i >= 0; i--)
             Children[i].Dispose();
 
@@ -1010,6 +1175,7 @@ public class GameObject : EngineObject, ISerializable
     {
         _enabled = state;
         HierarchyStateChanged();
+        UpdateEventDelegateState(_enabled && _enabledInHierarchy);
     }
 
     /// <summary>
@@ -1021,6 +1187,7 @@ public class GameObject : EngineObject, ISerializable
         if (_enabledInHierarchy != newState)
         {
             _enabledInHierarchy = newState;
+            UpdateEventDelegateState(newState);
             foreach (MonoBehaviour component in GetComponents<MonoBehaviour>())
                 component.HierarchyStateChanged();
         }

--- a/Prowl.Runtime/GameObject/MonoBehaviour.cs
+++ b/Prowl.Runtime/GameObject/MonoBehaviour.cs
@@ -2,11 +2,14 @@
 // Licensed under the MIT License. See the LICENSE file in the project root for details.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 
 using Prowl.Echo;
 using Prowl.PaperUI;
+using Prowl.Runtime.Events;
 using Prowl.Runtime.Rendering;
 using Prowl.Runtime.Resources;
 using Prowl.Vector;
@@ -89,6 +92,96 @@ public abstract class MonoBehaviour : EngineObject, ISerializationCallbackReceiv
     /// </summary>
     public string Tag => _go.Tag;
 
+    #region Override Detection Cache
+
+    [Flags]
+    private enum OverrideFlags : byte
+    {
+        None            = 0,
+        Update          = 1 << 0,
+        LateUpdate      = 1 << 1,
+        FixedUpdate     = 1 << 2,
+        OnRenderCollect = 1 << 3,
+        OnGui           = 1 << 4,
+        DrawGizmos      = 1 << 5,
+    }
+
+    private static readonly ConcurrentDictionary<Type, OverrideFlags> s_overrideCache = new();
+
+    private static OverrideFlags DetectOverrides(Type type)
+    {
+        return s_overrideCache.GetOrAdd(type, static t =>
+        {
+            OverrideFlags flags = OverrideFlags.None;
+            Type baseType = typeof(MonoBehaviour);
+
+            if (t.GetMethod(nameof(Update), BindingFlags.Instance | BindingFlags.Public, Type.EmptyTypes)?.DeclaringType != baseType)
+                flags |= OverrideFlags.Update;
+            if (t.GetMethod(nameof(LateUpdate), BindingFlags.Instance | BindingFlags.Public, Type.EmptyTypes)?.DeclaringType != baseType)
+                flags |= OverrideFlags.LateUpdate;
+            if (t.GetMethod(nameof(FixedUpdate), BindingFlags.Instance | BindingFlags.Public, Type.EmptyTypes)?.DeclaringType != baseType)
+                flags |= OverrideFlags.FixedUpdate;
+            if (t.GetMethod(nameof(OnRenderCollect), BindingFlags.Instance | BindingFlags.Public, [typeof(SceneEvents.OnRenderCollectArgs)])?.DeclaringType != baseType)
+                flags |= OverrideFlags.OnRenderCollect;
+            if (t.GetMethod(nameof(OnGui), BindingFlags.Instance | BindingFlags.Public, [typeof(Paper)])?.DeclaringType != baseType)
+                flags |= OverrideFlags.OnGui;
+            if (t.GetMethod(nameof(DrawGizmos), BindingFlags.Instance | BindingFlags.Public, Type.EmptyTypes)?.DeclaringType != baseType)
+                flags |= OverrideFlags.DrawGizmos;
+
+            return flags;
+        });
+    }
+
+    [SerializeIgnore]
+    private OverrideFlags _overrides;
+
+    #endregion
+
+    private ExecutionOrder _executionOrder;
+
+    public ExecutionOrder ExecutionOrder
+    {
+        get
+        {
+            return _executionOrder;
+        }
+        set
+        {
+            _executionOrder = value;
+            if (_eventsInitialized && Scene.IsValid())
+            {
+                DisposeSceneEvents();
+                SubscribeSceneEvents(Scene);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Updates this component's <see cref="ExecutionOrder"/> based on its owning GameObject's
+    /// order and this component's index. Uses discriminator <c>0</c> so components sort
+    /// after their GO but before its children.
+    /// </summary>
+    public void UpdateExecutionOrder()
+    {
+        if (!GameObject.IsValid()) return;
+
+        ReadOnlySpan<int> goLevels = GameObject.ExecutionOrder.Levels;
+        int[] levels = new int[goLevels.Length + 2];
+        goLevels.CopyTo(levels);
+        levels[goLevels.Length] = 0; // discriminator: component
+        levels[goLevels.Length + 1] = GameObject._components.IndexOf(this);
+        ExecutionOrder = new ExecutionOrder(levels);
+    }
+
+    private EventDelegateContainer<SceneEvents.EventTypes, Unit> UpdateDelegate = null;
+    private EventDelegateContainer<SceneEvents.EventTypes, Unit> LateUpdateDelegate = null;
+    private EventDelegateContainer<SceneEvents.EventTypes, Unit> FixedUpdateDelegate = null;
+    private EventDelegateContainer<SceneEvents.EventTypes, SceneEvents.OnRenderCollectArgs> OnRenderCollectDelegate = null;
+    private EventDelegateContainer<SceneEvents.EventTypes, Paper> OnGuiDelegate = null;
+    private EventDelegateContainer<SceneEvents.EventTypes, Unit> DrawGizmosDelegate = null;
+
+    private bool _eventsInitialized = false;
+
     /// <summary>
     /// Gets or sets whether the MonoBehaviour is enabled.
     /// </summary>
@@ -101,6 +194,7 @@ public abstract class MonoBehaviour : EngineObject, ISerializationCallbackReceiv
             {
                 _enabled = value;
                 HierarchyStateChanged();
+                UpdateEventDelegateState(_enabled && _enabledInHierarchy);
             }
         }
     }
@@ -237,6 +331,76 @@ public abstract class MonoBehaviour : EngineObject, ISerializationCallbackReceiv
                 else
                     InternalOnDisable();
             }
+
+            // Sync event subscriptions so disabled-in-hierarchy objects stop receiving Update/FixedUpdate etc.
+            if (_eventsInitialized)
+                UpdateEventDelegateState(newState);
+        }
+    }
+
+    private void DisposeSceneEvents()
+    {
+        if (_eventsInitialized)
+        {
+            UpdateDelegate?.Dispose();
+            LateUpdateDelegate?.Dispose();
+            FixedUpdateDelegate?.Dispose();
+            OnRenderCollectDelegate?.Dispose();
+            OnGuiDelegate?.Dispose();
+            DrawGizmosDelegate?.Dispose();
+
+            _eventsInitialized = false;
+        }
+    }
+
+    internal void SubscribeSceneEvents(Scene scene)
+    {
+        _overrides = DetectOverrides(GetType());
+
+        if (_overrides.HasFlag(OverrideFlags.Update))
+            UpdateDelegate = scene.Events.Update.Subscribe(InternalUpdate, ExecutionOrder);
+        if (_overrides.HasFlag(OverrideFlags.LateUpdate))
+            LateUpdateDelegate = scene.Events.LateUpdate.Subscribe(InternalLateUpdate, ExecutionOrder);
+        if (_overrides.HasFlag(OverrideFlags.FixedUpdate))
+            FixedUpdateDelegate = scene.Events.FixedUpdate.Subscribe(InternalFixedUpdate, ExecutionOrder);
+        if (_overrides.HasFlag(OverrideFlags.OnRenderCollect))
+            OnRenderCollectDelegate = scene.Events.OnRenderCollect.Subscribe(OnRenderCollect, ExecutionOrder);
+        if (_overrides.HasFlag(OverrideFlags.OnGui))
+            OnGuiDelegate = scene.Events.OnGui.Subscribe(OnGui, ExecutionOrder);
+        if (_overrides.HasFlag(OverrideFlags.DrawGizmos))
+            DrawGizmosDelegate = scene.Events.DrawGizmos.Subscribe(DrawGizmos, ExecutionOrder);
+
+        _eventsInitialized = true;
+
+        // Apply current effective state immediately (in case the MB or its GO ancestors are disabled at subscription time)
+        UpdateEventDelegateState(_enabled && _enabledInHierarchy);
+    }
+
+    internal void UpdateEventDelegateState(bool enable)
+    {
+        if (!_eventsInitialized)
+        {
+            Scene?.ToSubscribe.Add(this);
+            return;
+        }
+
+        if (enable)
+        {
+            UpdateDelegate?.Enable();
+            LateUpdateDelegate?.Enable();
+            FixedUpdateDelegate?.Enable();
+            OnRenderCollectDelegate?.Enable();
+            OnGuiDelegate?.Enable();
+            DrawGizmosDelegate?.Enable();
+        }
+        else
+        {
+            UpdateDelegate?.Disable();
+            LateUpdateDelegate?.Disable();
+            FixedUpdateDelegate?.Disable();
+            OnRenderCollectDelegate?.Disable();
+            OnGuiDelegate?.Disable();
+            DrawGizmosDelegate?.Disable();
         }
     }
 
@@ -312,7 +476,7 @@ public abstract class MonoBehaviour : EngineObject, ISerializationCallbackReceiv
     /// Components add their renderables/lights to the provided lists.
     /// Camera is provided for LOD and distance-based decisions.
     /// </summary>
-    public virtual void OnRenderCollect(Camera camera, List<IRenderable> renderables, List<IRenderableLight> lights) { }
+    public virtual void OnRenderCollect(SceneEvents.OnRenderCollectArgs onRenderCollectArgs) { }
 
     /// <summary>
     /// Called for rendering and handling GUI gizmos.
@@ -395,6 +559,8 @@ public abstract class MonoBehaviour : EngineObject, ISerializationCallbackReceiv
     /// </summary>
     public override void OnDispose()
     {
+        DisposeSceneEvents();
+
         if (GameObject.IsValid())
             GameObject.RemoveComponent(this);
     }

--- a/Prowl.Runtime/GameObject/MonoBehaviour.cs
+++ b/Prowl.Runtime/GameObject/MonoBehaviour.cs
@@ -296,6 +296,8 @@ public abstract class MonoBehaviour : EngineObject, ISerializationCallbackReceiv
 
         // Insert at new position
         GameObject._components.Insert(index, this);
+
+        GameObject.Scene?.MarkExecutionOrdersDirty();
     }
     #endregion
 
@@ -309,6 +311,8 @@ public abstract class MonoBehaviour : EngineObject, ISerializationCallbackReceiv
 
         bool isEnabled = _enabled && _go.EnabledInHierarchy;
         _enabledInHierarchy = isEnabled;
+
+        _go.Scene?.MarkExecutionOrdersDirty();
     }
 
     /// <summary>
@@ -358,17 +362,17 @@ public abstract class MonoBehaviour : EngineObject, ISerializationCallbackReceiv
         _overrides = DetectOverrides(GetType());
 
         if (_overrides.HasFlag(OverrideFlags.Update))
-            UpdateDelegate = scene.Events.Update.Subscribe(InternalUpdate, ExecutionOrder);
+            UpdateDelegate = scene.Events.Update.Subscribe(InternalUpdate, ExecutionOrder, allowMultiple: true);
         if (_overrides.HasFlag(OverrideFlags.LateUpdate))
-            LateUpdateDelegate = scene.Events.LateUpdate.Subscribe(InternalLateUpdate, ExecutionOrder);
+            LateUpdateDelegate = scene.Events.LateUpdate.Subscribe(InternalLateUpdate, ExecutionOrder, allowMultiple: true);
         if (_overrides.HasFlag(OverrideFlags.FixedUpdate))
-            FixedUpdateDelegate = scene.Events.FixedUpdate.Subscribe(InternalFixedUpdate, ExecutionOrder);
+            FixedUpdateDelegate = scene.Events.FixedUpdate.Subscribe(InternalFixedUpdate, ExecutionOrder, allowMultiple: true);
         if (_overrides.HasFlag(OverrideFlags.OnRenderCollect))
-            OnRenderCollectDelegate = scene.Events.OnRenderCollect.Subscribe(OnRenderCollect, ExecutionOrder);
+            OnRenderCollectDelegate = scene.Events.OnRenderCollect.Subscribe(OnRenderCollect, ExecutionOrder, allowMultiple: true);
         if (_overrides.HasFlag(OverrideFlags.OnGui))
-            OnGuiDelegate = scene.Events.OnGui.Subscribe(OnGui, ExecutionOrder);
+            OnGuiDelegate = scene.Events.OnGui.Subscribe(OnGui, ExecutionOrder, allowMultiple: true);
         if (_overrides.HasFlag(OverrideFlags.DrawGizmos))
-            DrawGizmosDelegate = scene.Events.DrawGizmos.Subscribe(DrawGizmos, ExecutionOrder);
+            DrawGizmosDelegate = scene.Events.DrawGizmos.Subscribe(DrawGizmos, ExecutionOrder, allowMultiple: true);
 
         _eventsInitialized = true;
 

--- a/Prowl.Runtime/Prowl.Runtime.csproj
+++ b/Prowl.Runtime/Prowl.Runtime.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -36,6 +36,13 @@
     <PackageReference Include="Silk.NET" Version="2.23.0" />
     <PackageReference Include="Silk.NET.OpenAL.Soft.Native" Version="1.23.1" />
     <!-- <PackageReference Include="Silk.NET.OpenAL.Soft.Native" Version="1.23.1" /> -->
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Prowl.Runtime.Generators\Prowl.Runtime.Generators.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false"
+                      PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Prowl.Runtime/Resources/Scene.cs
+++ b/Prowl.Runtime/Resources/Scene.cs
@@ -112,6 +112,16 @@ public class Scene : EngineObject, ISerializationCallbackReceiver
     private object _lock;
     public HashSet<EngineObject> ToSubscribe = new(ReferenceEqualityComparer.Instance);
 
+    [SerializeIgnore]
+    private bool _executionOrdersDirty;
+
+    /// <summary>
+    /// Marks that the execution orders (priorities for event subscriptions) are out of date
+    /// due to hierarchy changes. The orders will be recalculated once at the start of the
+    /// next frame, before any new object event subscriptions are processed.
+    /// </summary>
+    public void MarkExecutionOrdersDirty() => _executionOrdersDirty = true;
+
     public struct FogParams
     {
         public enum FogMode
@@ -294,7 +304,7 @@ public class Scene : EngineObject, ISerializationCallbackReceiver
     {
         if (_isActive) throw new Exception("Scene is already enabled!");
 
-        Events.OnBeforeUpdates.Subscribe(SubscribeObjectsToEvents);
+        Events.OnBeforeUpdates.Subscribe(SubscribeObjectsToEvents, allowMultiple: true);
 
         _isActive = true;
 
@@ -322,6 +332,13 @@ public class Scene : EngineObject, ISerializationCallbackReceiver
 
     public void SubscribeObjectsToEvents()
     {
+        // Ensure execution orders (used as subscription priorities) are up-to-date
+        // exactly once per frame, before we process any pending object subscriptions.
+        if (_executionOrdersDirty)
+        {
+            RecalculateExecutionOrders();
+        }
+
         Events.Manager.BeginBatch();
         ReadOnlySpan<EngineObject> list = CollectionsMarshal.AsSpan(ToSubscribe.ToList());
         ToSubscribe.Clear();
@@ -374,7 +391,6 @@ public class Scene : EngineObject, ISerializationCallbackReceiver
         _isActive = false;
     }
 
-
     /// <summary>
     /// Registers a GameObject and all of its children.
     /// </summary>
@@ -402,6 +418,8 @@ public class Scene : EngineObject, ISerializationCallbackReceiver
         index = Math.Max(0, Math.Min(index, rootIndices.Count));
         int insertAt = index < rootIndices.Count ? rootIndices[index] : _allObj.Count;
         _allObj.Insert(insertAt, obj);
+
+        MarkExecutionOrdersDirty();
     }
 
     /// <summary>
@@ -561,6 +579,8 @@ public class Scene : EngineObject, ISerializationCallbackReceiver
     /// </summary>
     public void RecalculateExecutionOrders()
     {
+        _executionOrdersDirty = false;
+        Events.Manager.BeginBatch();
         // Stack-based DFS. Each entry carries the parent's levels array.
         // Children are built as (parentLevels + [1, childIndex]).
         var stack = new Stack<(GameObject go, int[] parentLevels, int siblingIndex)>();
@@ -611,6 +631,7 @@ public class Scene : EngineObject, ISerializationCallbackReceiver
             for (int i = children.Count - 1; i >= 0; i--)
                 stack.Push((children[i], goLevels, i));
         }
+        Events.Manager.EndBatch();
     }
 
     /// <summary> Unregisters all GameObjects. </summary>
@@ -723,6 +744,8 @@ public class Scene : EngineObject, ISerializationCallbackReceiver
 
         foreach (GameObject obj in serializeObj)
             Add(obj);
+
+        MarkExecutionOrdersDirty();
     }
 
     /// <summary>

--- a/Prowl.Runtime/Resources/Scene.cs
+++ b/Prowl.Runtime/Resources/Scene.cs
@@ -1,12 +1,14 @@
-// This file is part of the Prowl Game Engine
+﻿// This file is part of the Prowl Game Engine
 // Licensed under the MIT License. See the LICENSE file in the project root for details.
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 
 using Prowl.Echo;
 using Prowl.PaperUI;
+using Prowl.Runtime.Events;
 using Prowl.Runtime.Rendering;
 using Prowl.Vector;
 
@@ -102,8 +104,13 @@ public class Scene : EngineObject, ISerializationCallbackReceiver
 
     public PhysicsWorld Physics => _physics;
 
+    public SceneEvents Events { get; } = new();
+
     [SerializeIgnore]
     private bool _isActive = false;
+
+    private object _lock;
+    public HashSet<EngineObject> ToSubscribe = new(ReferenceEqualityComparer.Instance);
 
     public struct FogParams
     {
@@ -287,6 +294,8 @@ public class Scene : EngineObject, ISerializationCallbackReceiver
     {
         if (_isActive) throw new Exception("Scene is already enabled!");
 
+        Events.OnBeforeUpdates.Subscribe(SubscribeObjectsToEvents);
+
         _isActive = true;
 
         // Create a copy to avoid collection modification during enumeration
@@ -309,6 +318,28 @@ public class Scene : EngineObject, ISerializationCallbackReceiver
                 }
             }
         }
+    }
+
+    public void SubscribeObjectsToEvents()
+    {
+        Events.Manager.BeginBatch();
+        ReadOnlySpan<EngineObject> list = CollectionsMarshal.AsSpan(ToSubscribe.ToList());
+        ToSubscribe.Clear();
+        for (int i = 0; i < list.Length; i++)
+        {
+
+            EngineObject obj = list[i];
+            if (obj.IsDisposed) continue;
+            if (obj is GameObject go)
+            {
+                go.SubscribeSceneEvents(this);
+            }
+            else if (obj is MonoBehaviour mb)
+            {
+                mb.SubscribeSceneEvents(this);
+            }
+        }
+        Events.Manager.EndBatch();
     }
 
     /// <summary>
@@ -516,6 +547,72 @@ public class Scene : EngineObject, ISerializationCallbackReceiver
         return null;
     }
 
+    /// <summary>
+    /// Assigns an <see cref="ExecutionOrder"/> to every GameObject and MonoBehaviour
+    /// based on its position in the scene hierarchy using a depth-first traversal.
+    /// <para>
+    /// Order scheme per GO at hierarchy levels <c>[L0, L1, …, Ln]</c>:
+    /// <list type="bullet">
+    ///   <item>GameObject itself:  <c>(L0, L1, …, Ln)</c></item>
+    ///   <item>Component i:        <c>(L0, L1, …, Ln, 0, i)</c>  — <c>0</c> discriminator sorts before children</item>
+    ///   <item>Child j:            <c>(L0, L1, …, Ln, 1, j)</c>  — <c>1</c> discriminator sorts after components</item>
+    /// </list>
+    /// </para>
+    /// </summary>
+    public void RecalculateExecutionOrders()
+    {
+        // Stack-based DFS. Each entry carries the parent's levels array.
+        // Children are built as (parentLevels + [1, childIndex]).
+        var stack = new Stack<(GameObject go, int[] parentLevels, int siblingIndex)>();
+
+        // Push roots in reverse so first root is processed first.
+        var roots = RootObjects.ToList();
+        for (int i = roots.Count - 1; i >= 0; i--)
+            stack.Push((roots[i], [], i));
+
+        while (stack.Count > 0)
+        {
+            (GameObject go, int[] parentLevels, int sibIdx) = stack.Pop();
+
+            if (go.IsDisposed) continue;
+
+            // GO priority = parentLevels + (1, siblingIndex), or just (siblingIndex) for roots.
+            int[] goLevels;
+            if (parentLevels.Length == 0)
+            {
+                goLevels = [sibIdx];
+            }
+            else
+            {
+                goLevels = new int[parentLevels.Length + 2];
+                parentLevels.CopyTo(goLevels, 0);
+                goLevels[parentLevels.Length] = 1;     // discriminator: child
+                goLevels[parentLevels.Length + 1] = sibIdx;
+            }
+
+            go.ExecutionOrder = new ExecutionOrder(goLevels);
+
+            // Components: (goLevels + [0, componentIndex])
+            ReadOnlySpan<MonoBehaviour> components = go.GetComponentsAsSpan<MonoBehaviour>();
+            if (components.Length > 0)
+            {
+                int[] compLevels = new int[goLevels.Length + 2];
+                goLevels.CopyTo(compLevels, 0);
+                compLevels[goLevels.Length] = 0; // discriminator: component (sorts before children)
+                for (int c = 0; c < components.Length; c++)
+                {
+                    compLevels[compLevels.Length - 1] = c;
+                    components[c].ExecutionOrder = new ExecutionOrder((int[])compLevels.Clone());
+                }
+            }
+
+            // Push children in reverse order so first child is processed first.
+            List<GameObject> children = go.Children;
+            for (int i = children.Count - 1; i >= 0; i--)
+                stack.Push((children[i], goLevels, i));
+        }
+    }
+
     /// <summary> Unregisters all GameObjects. </summary>
     public void Clear()
     {
@@ -530,6 +627,8 @@ public class Scene : EngineObject, ISerializationCallbackReceiver
     /// <summary> Unregisters all dead / disposed GameObjects </summary>
     public void Flush()
     {
+        Events?.OnFlush.Invoke();
+        return;
         List<GameObject> removed = [];
         foreach (GameObject obj in _allObj)
         {
@@ -542,6 +641,16 @@ public class Scene : EngineObject, ISerializationCallbackReceiver
 
         foreach (GameObject obj in removed)
             obj.Scene = null;
+    }
+
+    public void Flush(GameObject gameObject)
+    {
+        if (gameObject.IsDisposed)
+        {
+            _allObj.Remove(gameObject);
+            _allObjSet.Remove(gameObject);
+            gameObject.Scene = null;
+        }
     }
 
     public override void OnDispose()
@@ -623,13 +732,29 @@ public class Scene : EngineObject, ISerializationCallbackReceiver
     /// </summary>
     public void Update()
     {
-        List<GameObject> activeGOs = [.. ActiveObjects];
-        foreach (GameObject go in activeGOs)
-            go.PreUpdate();
+        //List<GameObject> activeGOs = [.. ActiveObjects];
 
-        ForeachComponent(activeGOs, (x) => x.InternalUpdate());
+        //ReadOnlySpan<GameObject> activeGOs = CollectionsMarshal.AsSpan(ActiveObjectsList);
 
-        ForeachComponent(activeGOs, (x) => x.InternalLateUpdate());
+        //for (int i = 0;i < activeGOs.Length; i++)
+        //{
+        //        GameObject go = activeGOs[i];
+        //        go.PreUpdate();
+        //}
+
+
+        Events.OnBeforeUpdates.Invoke();
+
+        Events.PreUpdate.Invoke();
+        Events.Update.Invoke();
+        Events.LateUpdate.Invoke();
+
+        //foreach (GameObject go in activeGOs)
+        //    go.PreUpdate();
+
+        //ForeachComponent(activeGOs, (x) => x.InternalUpdate());
+
+        //ForeachComponent(activeGOs, (x) => x.InternalLateUpdate());
 
         Flush();
     }
@@ -642,8 +767,10 @@ public class Scene : EngineObject, ISerializationCallbackReceiver
     {
         Physics.Update();
 
-        List<GameObject> activeGOs = [.. ActiveObjects];
-        ForeachComponent(activeGOs, (x) => x.InternalFixedUpdate());
+        Events.FixedUpdate.Invoke();
+
+        //ReadOnlySpan<GameObject> activeGOs = CollectionsMarshal.AsSpan(ActiveObjectsList);
+        //ForeachComponent(activeGOs, (x) => x.InternalFixedUpdate());
 
         Flush();
     }
@@ -654,11 +781,7 @@ public class Scene : EngineObject, ISerializationCallbackReceiver
     /// </summary>
     public void CollectRenderables(Camera camera, List<IRenderable> renderables, List<IRenderableLight> lights)
     {
-        List<GameObject> activeGOs = [.. ActiveObjects];
-        ForeachComponent(activeGOs, (x) =>
-        {
-            x.OnRenderCollect(camera, renderables, lights);
-        });
+        Events.OnRenderCollect.Invoke(new(camera, renderables, lights));
     }
 
     /// <summary>
@@ -666,13 +789,7 @@ public class Scene : EngineObject, ISerializationCallbackReceiver
     /// </summary>
     public void DrawGizmos()
     {
-        List<GameObject> activeGOs = [.. ActiveObjects];
-        ForeachComponent(activeGOs, (x) =>
-        {
-            if (!x.HideFlags.HasFlag(HideFlags.NoGizmos))
-                x.DrawGizmos();
-        });
-
+        Events.DrawGizmos.Invoke();
         Flush();
     }
 
@@ -682,12 +799,7 @@ public class Scene : EngineObject, ISerializationCallbackReceiver
     /// </summary>
     public void OnGui(Paper paper)
     {
-        List<GameObject> activeGOs = [.. ActiveObjects];
-        ForeachComponent(activeGOs, (x) =>
-        {
-            x.OnGui(paper);
-        });
-
+        Events.OnGui.Invoke(paper);
         Flush();
     }
 

--- a/Prowl.Runtime/Window.cs
+++ b/Prowl.Runtime/Window.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Runtime.InteropServices;
 
+using Prowl.Runtime.Events;
+
 using Silk.NET.Input;
 using Silk.NET.Maths;
 using Silk.NET.Windowing;
@@ -169,16 +171,17 @@ public static class Window
         InternalWindow.Resize += OnResize;
         InternalWindow.FramebufferResize += OnFramebufferResize;
         InternalWindow.Move += OnMove;
-        InternalWindow.StateChanged += (state) => StateChanged?.Invoke(state);
-        InternalWindow.FileDrop += (files) => FileDrop?.Invoke(files);
+        InternalWindow.StateChanged += (state) => { StateChanged?.Invoke(state); WindowEvents.StateChanged.Invoke(new WindowEvents.WindowStateArgs(state)); };
+        InternalWindow.FileDrop += (files) => { FileDrop?.Invoke(files); WindowEvents.FileDrop.Invoke(new WindowEvents.FileDropArgs(files)); };
         InternalWindow.FocusChanged += (focused) =>
         {
             isFocused = focused;
             FocusChanged?.Invoke(focused);
+            WindowEvents.FocusChanged.Invoke(new WindowEvents.BoolArgs(focused));
         };
     }
 
-    private static void OnMove(Vector2D<int> d) => Move?.Invoke(d);
+    private static void OnMove(Vector2D<int> d) { Move?.Invoke(d); WindowEvents.Move.Invoke(new WindowEvents.Vector2IntArgs(d)); }
 
     public static void Start()
     {
@@ -192,6 +195,7 @@ public static class Window
         // has a live render thread to drain its CBs; otherwise it would deadlock.
         Graphics.BeginFrame();
         Load?.Invoke();
+        WindowEvents.Load.Invoke();
         Graphics.EndFrameAndWait();
 
         try { MainLoop(); }
@@ -216,9 +220,12 @@ public static class Window
 
             InternalWindow.DoEvents();
             Update?.Invoke(delta);
+            WindowEvents.Update.Invoke(new WindowEvents.FloatArgs(delta));
             WindowInputHandler?.LateUpdate();
             Render?.Invoke(delta);
+            WindowEvents.Render.Invoke(delta);
             PostRender?.Invoke(delta);
+            WindowEvents.PostRender.Invoke(new WindowEvents.FloatArgs(delta));
 
             // SwapBuffers runs on the render thread as part of the frame-end
             // sentinel no context handoff per frame.
@@ -236,8 +243,8 @@ public static class Window
         Input.PushHandler(WindowInputHandler);
     }
 
-    public static void OnResize(Vector2D<int> size) => Resize?.Invoke(size);
-    public static void OnFramebufferResize(Vector2D<int> size) => FramebufferResize?.Invoke(size);
+    public static void OnResize(Vector2D<int> size) { Resize?.Invoke(size); WindowEvents.Resize.Invoke(size); }
+    public static void OnFramebufferResize(Vector2D<int> size) { FramebufferResize?.Invoke(size); WindowEvents.FramebufferResize.Invoke(new WindowEvents.Vector2IntArgs(size)); }
 
     public static void OnClose()
     {
@@ -245,6 +252,7 @@ public static class Window
         // otherwise race scene unload and try to submit GPU work after the render thread exits).
         AssetLoader.Stop();
         Closing?.Invoke();
+        WindowEvents.Closing.Invoke();
         WindowInputHandler.Dispose();
         Graphics.Dispose();
     }

--- a/Prowl.sln
+++ b/Prowl.sln
@@ -31,6 +31,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BananaMan", "Samples\Banana
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Prowl.Editor", "Prowl.Editor\Prowl.Editor.csproj", "{F0DFDD68-2F29-4637-9C99-D42CC53F21A3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Prowl.Runtime.Generators", "Prowl.Runtime.Generators\Prowl.Runtime.Generators.csproj", "{DE93BF43-6456-407E-84FB-37F461838BD8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -197,6 +199,18 @@ Global
 		{F0DFDD68-2F29-4637-9C99-D42CC53F21A3}.Release|x64.Build.0 = Release|Any CPU
 		{F0DFDD68-2F29-4637-9C99-D42CC53F21A3}.Release|x86.ActiveCfg = Release|Any CPU
 		{F0DFDD68-2F29-4637-9C99-D42CC53F21A3}.Release|x86.Build.0 = Release|Any CPU
+		{DE93BF43-6456-407E-84FB-37F461838BD8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DE93BF43-6456-407E-84FB-37F461838BD8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DE93BF43-6456-407E-84FB-37F461838BD8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DE93BF43-6456-407E-84FB-37F461838BD8}.Debug|x64.Build.0 = Debug|Any CPU
+		{DE93BF43-6456-407E-84FB-37F461838BD8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DE93BF43-6456-407E-84FB-37F461838BD8}.Debug|x86.Build.0 = Debug|Any CPU
+		{DE93BF43-6456-407E-84FB-37F461838BD8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DE93BF43-6456-407E-84FB-37F461838BD8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DE93BF43-6456-407E-84FB-37F461838BD8}.Release|x64.ActiveCfg = Release|Any CPU
+		{DE93BF43-6456-407E-84FB-37F461838BD8}.Release|x64.Build.0 = Release|Any CPU
+		{DE93BF43-6456-407E-84FB-37F461838BD8}.Release|x86.ActiveCfg = Release|Any CPU
+		{DE93BF43-6456-407E-84FB-37F461838BD8}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Samples/FlyCamera/Program.cs
+++ b/Samples/FlyCamera/Program.cs
@@ -18,6 +18,7 @@
 //
 
 using Prowl.Runtime;
+using Prowl.Runtime.Events;
 using Prowl.Runtime.Rendering;
 using Prowl.Runtime.Resources;
 using Prowl.Vector;
@@ -243,10 +244,11 @@ public sealed class VoxelPlanet : MonoBehaviour
         }
     }
 
-    public override void OnRenderCollect(Camera renderCamera, List<IRenderable> renderables, List<IRenderableLight> lights)
+    public override void OnRenderCollect(SceneEvents.OnRenderCollectArgs onRenderCollectArgs)
+
     {
         if (rootNode != null)
-            rootNode.Collect(renderables);
+            rootNode.Collect(onRenderCollectArgs.renderables);
     }
 
     public override void DrawGizmos()


### PR DESCRIPTION
Instead of iterating over all the active objects to gather the renderables, call updates, call fixedupdates, etc..., this implementation has the objects subscribed to an event manager that reduces the call overhead by a lot. 
Among other notable improvements, there are: 
- guaranteed execution order
- smaller memory footprint
- overall performance benefits

Following are two small benchmarks ran with ~1800 gameobjects with 7 monobehaviour each, for a total of ~12600 monobehaviours. each with an Update that rotates the transform.
before:
<img width="1039" height="153" alt="Screenshot 2026-06-12 152111" src="https://github.com/user-attachments/assets/83c9d444-845c-45a3-9577-01da79f397d0" />
after:
<img width="1024" height="139" alt="Screenshot 2026-06-12 150314" src="https://github.com/user-attachments/assets/caaf23cb-e672-4f6b-bda1-a6b0f1031d55" />
