### PR TITLE
Add .vscode/* launch configuration for VS Code users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,7 @@ artifacts/
 **/Properties/launchSettings.json
 
 # VS Code
-.vscode/
+# .vscode/
 
 *_i.c
 *_p.c
@@ -327,7 +327,7 @@ MigrationBackup/
 FodyWeavers.xsd
 
 # VS Code files for those working on multiple tools
-.vscode
+# .vscode
 *.code-workspace
 
 # Local History for Visual Studio Code

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Prowl.Editor (Debug)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build: Prowl.Editor Debug",
+            "program": "${workspaceFolder}/Build/Editor/Debug/net10.0/Prowl.Editor.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": false
+        },
+        {
+            "name": "Prowl.Editor (Release)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build: Prowl.Editor Release",
+            "program": "${workspaceFolder}/Build/Editor/Release/net10.0/Prowl.Editor.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": false,
+            "justMyCode": false
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "editor.detectIndentation": false,
+  "editor.autoIndentOnPasteWithinString": true,
+  "editor.tabSize": 4
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,31 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build: Prowl.Editor Debug",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/Prowl.Editor/Prowl.Editor.csproj",
+                "-c", "Debug"
+            ],
+            "group": "build",
+            "presentation": { "reveal": "silent" },
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "build: Prowl.Editor Release",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/Prowl.Editor/Prowl.Editor.csproj",
+                "-c", "Release"
+            ],
+            "group": "build",
+            "presentation": { "reveal": "silent" },
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}


### PR DESCRIPTION
Nice pretty menu dropdown with release mode launch options :)

<img width="532" height="407" alt="Screenshot 2026-06-18 at 7 53 39 PM" src="https://github.com/user-attachments/assets/a075367e-6d8c-4697-9292-b63045a06e5c" />
